### PR TITLE
fix(scanner): detect nested Python workspaces in declared monorepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
-    "test": "pnpm build && node --test tests/detectors.test.ts",
+    "test": "pnpm build && tsx --test tests/detectors.test.ts",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -212,39 +212,15 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
         } catch {}
       }
     }
-  } else {
-    // No manifest-declared monorepo — scan top-level subdirs for any stack
-    // (JS or non-JS) to catch mixed repos like Swift+React, Python+JS, etc.
-    try {
-      const topDirs = await readdir(root, { withFileTypes: true });
-      for (const d of topDirs) {
-        if (!d.isDirectory() || d.name.startsWith(".") || IGNORE_DIRS.has(d.name)) continue;
-        const wsPath = join(root, d.name);
-        // detectWorkspace handles both JS (package.json) and non-JS manifests
-        const wsInfo = await detectWorkspace(root, wsPath, d.name);
-        if (wsInfo) workspaces.push(wsInfo);
-        // Depth-2 discovery — always runs, not as fallback. Catches nested
-        // workspaces in container dirs (e.g. `repos/Engine/`, `apps/web/`,
-        // `services/api/`) even when the container itself matched (e.g. via
-        // PR #15 Python subdir scan hijacking the slot).
-        try {
-          const nestedDirs = await readdir(wsPath, { withFileTypes: true });
-          for (const n of nestedDirs) {
-            if (!n.isDirectory() || n.name.startsWith(".") || IGNORE_DIRS.has(n.name)) continue;
-            const nestedPath = join(wsPath, n.name);
-            const nestedInfo = await detectWorkspace(root, nestedPath, n.name);
-            if (nestedInfo) {
-              // De-dupe by relative path
-              const dup = workspaces.find((w) => w.path === nestedInfo.path);
-              if (!dup) workspaces.push(nestedInfo);
-            }
-          }
-        } catch {}
-      }
-    } catch {}
-    // Treat as implicit monorepo when multiple distinct stacks are found
-    if (workspaces.length >= 2) isMonorepo = true;
   }
+
+  // Always scan top-level and depth-2 directories for implicit workspaces.
+  // This catches undeclared backends in mixed repos and declared monorepos
+  // whose workspace globs do not cover non-JS service paths.
+  await discoverImplicitWorkspaces(root, workspaces);
+
+  // Treat as implicit monorepo when multiple distinct stacks are found
+  if (!isMonorepo && workspaces.length >= 2) isMonorepo = true;
 
   // Aggregate all workspace deps (always — not just for declared monorepos)
   let allDeps = { ...deps };
@@ -309,6 +285,77 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
     workspaces,
     language,
   };
+}
+
+async function discoverImplicitWorkspaces(
+  repoRoot: string,
+  workspaces: WorkspaceInfo[]
+): Promise<void> {
+  try {
+    const topDirs = await readdir(repoRoot, { withFileTypes: true });
+    for (const d of topDirs) {
+      if (!d.isDirectory() || d.name.startsWith(".") || IGNORE_DIRS.has(d.name)) continue;
+      const wsPath = join(repoRoot, d.name);
+
+      if (await hasDirectWorkspaceManifest(wsPath)) {
+        const wsInfo = await detectWorkspace(repoRoot, wsPath, d.name);
+        if (wsInfo && !workspaces.some((w) => w.path === wsInfo.path)) {
+          workspaces.push(wsInfo);
+        }
+      }
+
+      // Depth-2 discovery — always runs, not as fallback. Catches nested
+      // workspaces in container dirs (e.g. `repos/Engine/`, `apps/web/`,
+      // `services/api/`, `container-dir/backend/`) even when the container
+      // itself also matched via subdirectory manifest detection.
+      try {
+        const nestedDirs = await readdir(wsPath, { withFileTypes: true });
+        for (const n of nestedDirs) {
+          if (!n.isDirectory() || n.name.startsWith(".") || IGNORE_DIRS.has(n.name)) continue;
+          const nestedPath = join(wsPath, n.name);
+          if (!(await hasDirectWorkspaceManifest(nestedPath))) continue;
+          const nestedInfo = await detectWorkspace(repoRoot, nestedPath, n.name);
+          if (nestedInfo && !workspaces.some((w) => w.path === nestedInfo.path)) {
+            workspaces.push(nestedInfo);
+          }
+        }
+      } catch {}
+    }
+  } catch {}
+}
+
+async function hasDirectWorkspaceManifest(dir: string): Promise<boolean> {
+  const directManifestNames = [
+    "package.json",
+    "composer.json",
+    "pubspec.yaml",
+    "Package.swift",
+    "requirements.txt",
+    "Pipfile",
+    "pyproject.toml",
+    "mix.exs",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+  ];
+
+  for (const manifest of directManifestNames) {
+    if (await fileExists(join(dir, manifest))) return true;
+  }
+
+  try {
+    const entries = await readdir(dir);
+    return entries.some((entry) =>
+      entry.endsWith(".xcodeproj") ||
+      entry.endsWith(".xcworkspace") ||
+      entry.endsWith(".csproj")
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function detectFrameworks(

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const FIXTURE_ROOT = join(import.meta.dirname!, "fixtures");
+const FIXTURE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 
 async function writeFixture(subdir: string, files: Record<string, string>) {
   const dir = join(FIXTURE_ROOT, subdir);
@@ -27,6 +28,34 @@ async function loadModules() {
   const { detectConfig } = await import("../dist/detectors/config.js");
   const { detectLibs } = await import("../dist/detectors/libs.js");
   return { collectFiles, detectProject, detectRoutes, detectSchemas, detectComponents, detectDependencyGraph, detectMiddleware, detectConfig, detectLibs };
+}
+
+async function assertFastApiSqlAlchemyDetection(mods: any, dir: string, workspacePath: string, forbiddenWorkspacePaths: string[] = []) {
+  const project = await mods.detectProject(dir);
+  assert.ok(project.frameworks.includes("fastapi"), `Expected fastapi in frameworks, got ${project.frameworks.join(", ")}`);
+  assert.ok(project.orms.includes("sqlalchemy"), `Expected sqlalchemy in ORMs, got ${project.orms.join(", ")}`);
+  for (const forbiddenPath of forbiddenWorkspacePaths) {
+    assert.ok(!project.workspaces.some((w: any) => w.path === forbiddenPath), `Did not expect workspace ${forbiddenPath}, got ${project.workspaces.map((w: any) => w.path).join(", ")}`);
+  }
+
+  const workspace = project.workspaces.find((w: any) => w.path === workspacePath);
+  assert.ok(workspace, `Expected workspace ${workspacePath}, got ${project.workspaces.map((w: any) => w.path).join(", ")}`);
+  assert.ok(workspace.frameworks.includes("fastapi"), `Expected fastapi in workspace frameworks, got ${workspace.frameworks.join(", ")}`);
+  assert.ok(workspace.orms.includes("sqlalchemy"), `Expected sqlalchemy in workspace ORMs, got ${workspace.orms.join(", ")}`);
+
+  const files = await mods.collectFiles(dir);
+  const routes = await mods.detectRoutes(files, project);
+  const schemas = await mods.detectSchemas(files, project);
+
+  assert.ok(routes.some((r: any) => r.method === "GET" && r.path === "/health"), `Expected GET /health route, got ${routes.map((r: any) => `${r.method} ${r.path}`).join(", ")}`);
+  assert.ok(routes.some((r: any) => r.method === "POST" && r.path === "/users"), `Expected POST /users route, got ${routes.map((r: any) => `${r.method} ${r.path}`).join(", ")}`);
+
+  const userSchema = schemas.find((s: any) => s.name === "User");
+  const postSchema = schemas.find((s: any) => s.name === "Post");
+  assert.ok(userSchema, `Expected User schema, got ${schemas.map((s: any) => s.name).join(", ")}`);
+  assert.ok(postSchema, `Expected Post schema, got ${schemas.map((s: any) => s.name).join(", ")}`);
+  assert.ok(userSchema.fields.some((f: any) => f.name === "email" && f.flags.includes("unique")));
+  assert.ok(postSchema.fields.some((f: any) => f.name === "user_id" && f.flags.includes("fk")));
 }
 
 // =================== ROUTE DETECTION TESTS ===================
@@ -495,5 +524,181 @@ describe("Framework Detection", async () => {
     assert.ok(project.workspaces.length >= 2);
     assert.ok(project.frameworks.includes("hono"));
     assert.equal(project.componentFramework, "react");
+  });
+});
+
+describe("Python Workspace Subdirectory Detection", async () => {
+  const mods = await loadModules();
+
+  it("detects FastAPI and SQLAlchemy in a custom-named root subdirectory", async () => {
+    const dir = await writeFixture("python-custom-subdir-root", {
+      "package.json": JSON.stringify({ name: "test", dependencies: { react: "^18.0.0" } }),
+      "src/App.tsx": `export default function App() { return <main>web</main>; }`,
+      "my-service-api/requirements.txt": "fastapi\nsqlalchemy\nuvicorn\n",
+      "my-service-api/main.py": `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/users")
+def create_user():
+    return {"created": True}
+`,
+      "my-service-api/models.py": `from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    posts = relationship("Post")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = relationship("User")
+`,
+    });
+
+    await assertFastApiSqlAlchemyDetection(mods, dir, "my-service-api");
+  });
+
+  it("detects FastAPI and SQLAlchemy in a custom-named services workspace", async () => {
+    const dir = await writeFixture("python-custom-subdir-workspaces", {
+      "package.json": JSON.stringify({ name: "test", workspaces: ["apps/*", "services/*"] }),
+      "apps/web/package.json": JSON.stringify({ name: "@test/web", dependencies: { react: "^18.0.0" } }),
+      "apps/web/src/App.tsx": `export default function App() { return <main>web</main>; }`,
+      "services/my-backend-service/requirements.txt": "fastapi\nsqlalchemy\nuvicorn\n",
+      "services/my-backend-service/main.py": `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/users")
+def create_user():
+    return {"created": True}
+`,
+      "services/my-backend-service/models.py": `from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    posts = relationship("Post")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = relationship("User")
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    assert.equal(project.isMonorepo, true);
+    await assertFastApiSqlAlchemyDetection(mods, dir, "services/my-backend-service", ["services"]);
+  });
+
+  it("detects FastAPI and SQLAlchemy from pyproject.toml in a custom workspace directory", async () => {
+    const dir = await writeFixture("python-custom-subdir-pyproject", {
+      "package.json": JSON.stringify({ name: "test", workspaces: ["apps/*", "services/*"] }),
+      "apps/web/package.json": JSON.stringify({ name: "@test/web", dependencies: { react: "^18.0.0" } }),
+      "services/custom-api/pyproject.toml": `[project]
+name = "custom-api"
+version = "0.1.0"
+dependencies = [
+  "fastapi>=0.110.0",
+  "sqlalchemy>=2.0.0",
+  "uvicorn>=0.29.0",
+]
+`,
+      "services/custom-api/main.py": `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/users")
+def create_user():
+    return {"created": True}
+`,
+      "services/custom-api/models.py": `from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    posts = relationship("Post")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = relationship("User")
+`,
+    });
+
+    await assertFastApiSqlAlchemyDetection(mods, dir, "services/custom-api", ["services"]);
+  });
+
+  it("detects an undeclared FastAPI backend nested under a container directory in a declared monorepo", async () => {
+    const dir = await writeFixture("python-nested-container-backend", {
+      "package.json": JSON.stringify({ name: "test", workspaces: ["apps/*"] }),
+      "apps/web/package.json": JSON.stringify({ name: "@test/web", dependencies: { react: "^18.0.0" } }),
+      "apps/web/src/App.tsx": `export default function App() { return <main>web</main>; }`,
+      "container-dir/custom-python-backend/requirements.txt": "fastapi\nsqlalchemy\nuvicorn\n",
+      "container-dir/custom-python-backend/main.py": `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/users")
+def create_user():
+    return {"created": True}
+`,
+      "container-dir/custom-python-backend/models.py": `from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    posts = relationship("Post")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = relationship("User")
+`,
+    });
+
+    await assertFastApiSqlAlchemyDetection(mods, dir, "container-dir/custom-python-backend", ["container-dir"]);
   });
 });


### PR DESCRIPTION
## Summary

This fixes a scanner gap where declared monorepos could miss nested Python backends that were not covered by workspace globs.

In practice, a repo could declare workspaces like `apps/*` and still contain a real FastAPI + SQLAlchemy backend under a different nested path such as `container-dir/custom-python-backend`. In that case, Codesight could fail to detect the backend and return 0 routes / 0 models even though the Python project was present and valid.

## Root Cause

Workspace discovery had two different behaviors:

- for declared monorepos, scanner only walked the configured workspace patterns
- for non-declared monorepos, scanner also performed implicit top-level and depth-2 discovery

That meant undeclared nested backends could still be found in some repos, but not in declared monorepos where workspace config existed but did not include the backend path.

## What Changed

### Scanner

Updated `src/scanner.ts` so implicit workspace discovery also runs for declared monorepos.

To avoid introducing false positives, implicit discovery now only promotes a directory to a workspace when it has a direct local manifest, such as:

- `package.json`
- `requirements.txt`
- `pyproject.toml`
- `Pipfile`
- `go.mod`
- `Gemfile`
- `Cargo.toml`
- `composer.json`
- `build.gradle` / `build.gradle.kts`
- `pom.xml`
- `mix.exs`
- `Package.swift`
- `.csproj`
- `.xcodeproj` / `.xcworkspace`

Depth-2 discovery is preserved so nested undeclared backends are still found.

This also prevents container-only directories like `services` or `container-dir` from being incorrectly added as workspaces just because one of their children contains Python dependencies.

### Tests

Updated `tests/detectors.test.ts` to add regression coverage for:

- custom root Python subdirectory layouts
- custom `services/*` Python workspaces
- `pyproject.toml`-based Python workspaces
- undeclared nested Python backends inside declared monorepos

The new assertions also verify that container-only directories are not incorrectly added as workspaces.

### Test Runner

Updated the `test` script in `package.json` to use `tsx --test`, and updated the test file path handling to be Node 18-compatible.

## Why This Approach

The goal here was to preserve declared workspace config as authoritative while still handling real-world repos that contain valid nested backends outside the configured workspace globs.

Broad implicit discovery fixed the missed-backend problem, but it also risked inventing synthetic container workspaces. Restricting implicit discovery to directories with direct manifests keeps the fix targeted and avoids changing workspace semantics more than necessary.

## Validation

Ran locally:

```bash
pnpm test
