### PR TITLE
fix(scanner): parse Poetry dependencies from pyproject.toml

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -934,36 +934,64 @@ async function getPythonDeps(root: string): Promise<string[]> {
     } catch {}
     try {
       const toml = await readFile(join(dir, "pyproject.toml"), "utf-8");
-      // Find [project] section then locate dependencies = [...]
-      // Use bracket counting to handle packages with extras like django[bcrypt]
-      const projectIdx = toml.indexOf("[project]");
-      if (projectIdx >= 0) {
-        const afterProject = toml.slice(projectIdx);
-        const depMatch = afterProject.match(/\bdependencies\s*=\s*\[/);
-        if (depMatch) {
-          const arrStart = projectIdx + (depMatch.index ?? 0) + depMatch[0].length - 1;
-          let depth = 1;
-          let pos = arrStart + 1;
-          let inStr = false;
-          while (pos < toml.length && depth > 0) {
-            const ch = toml[pos];
-            if (ch === '"' && toml[pos - 1] !== "\\") inStr = !inStr;
-            if (!inStr) {
-              if (ch === "[") depth++;
-              else if (ch === "]") depth--;
-            }
-            pos++;
-          }
-          const depsContent = toml.slice(arrStart + 1, pos - 1);
-          for (const m of depsContent.matchAll(/"([^"]+)"/g)) {
-            const name = m[1].split(/[>=<\[!~;]/)[0].trim().toLowerCase();
-            if (name && !deps.includes(name)) deps.push(name);
-          }
-        }
-      }
+      parsePyprojectProjectDependencies(toml, deps);
+      parsePyprojectPoetryDependencies(toml, deps);
     } catch {}
   }
   return deps;
+}
+
+function parsePyprojectProjectDependencies(toml: string, deps: string[]): void {
+  // Find [project] section then locate dependencies = [...]
+  // Use bracket counting to handle packages with extras like django[bcrypt]
+  const projectIdx = toml.indexOf("[project]");
+  if (projectIdx < 0) return;
+
+  const afterProject = toml.slice(projectIdx);
+  const depMatch = afterProject.match(/\bdependencies\s*=\s*\[/);
+  if (!depMatch) return;
+
+  const arrStart = projectIdx + (depMatch.index ?? 0) + depMatch[0].length - 1;
+  let depth = 1;
+  let pos = arrStart + 1;
+  let inStr = false;
+  while (pos < toml.length && depth > 0) {
+    const ch = toml[pos];
+    if (ch === '"' && toml[pos - 1] !== "\\") inStr = !inStr;
+    if (!inStr) {
+      if (ch === "[") depth++;
+      else if (ch === "]") depth--;
+    }
+    pos++;
+  }
+  const depsContent = toml.slice(arrStart + 1, pos - 1);
+  for (const m of depsContent.matchAll(/"([^"]+)"/g)) {
+    addPythonDep(m[1].split(/[>=<\[!~;]/)[0], deps);
+  }
+}
+
+function parsePyprojectPoetryDependencies(toml: string, deps: string[]): void {
+  const sectionMatch = toml.match(/^\[tool\.poetry\.dependencies\]\s*$/m);
+  if (!sectionMatch) return;
+
+  const sectionStart = (sectionMatch.index ?? 0) + sectionMatch[0].length;
+  const sectionBody = toml.slice(sectionStart);
+  for (const line of sectionBody.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[")) break;
+
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 0) continue;
+    const rawName = trimmed.slice(0, eqIdx).trim().replace(/^['"]|['"]$/g, "");
+    addPythonDep(rawName, deps);
+  }
+}
+
+function addPythonDep(rawName: string, deps: string[]): void {
+  const name = rawName.trim().toLowerCase().replace(/_/g, "-");
+  if (!name || name === "python" || name.startsWith("#") || deps.includes(name)) return;
+  deps.push(name);
 }
 
 async function getGoDeps(root: string): Promise<string[]> {

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -484,6 +484,55 @@ describe("Framework Detection", async () => {
     assert.ok(project.frameworks.includes("elysia"));
   });
 
+  it("detects Django from pyproject.toml Poetry dependencies", async () => {
+    const dir = await writeFixture("django-poetry-detect", {
+      "pyproject.toml": `[tool.poetry]
+name = "django-poetry-detect"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+Django = "^6.0"
+djangorestframework = "^3.16"
+`,
+      "urls.py": `from django.urls import path
+urlpatterns = [
+    path("api/users/", views.UserList.as_view()),
+]`,
+      "models.py": `from django.db import models
+
+class User(models.Model):
+    email = models.EmailField(unique=True)
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    assert.ok(project.frameworks.includes("django"));
+    assert.ok(project.orms.includes("django"));
+
+    const files = await mods.collectFiles(dir);
+    const routes = await mods.detectRoutes(files, project);
+    const schemas = await mods.detectSchemas(files, project);
+    assert.equal(routes.length, 1);
+    assert.ok(schemas.some((s: any) => s.name === "User"));
+  });
+
+  it("does not detect Django from Poetry dev-only dependency groups", async () => {
+    const dir = await writeFixture("django-poetry-dev-only", {
+      "pyproject.toml": `[tool.poetry]
+name = "django-poetry-dev-only"
+version = "0.1.0"
+
+[tool.poetry.group.dev.dependencies]
+Django = "^6.0"
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    assert.ok(!project.frameworks.includes("django"), `Did not expect django framework, got ${project.frameworks.join(", ")}`);
+    assert.ok(!project.orms.includes("django"), `Did not expect django ORM, got ${project.orms.join(", ")}`);
+  });
+
   it("detects monorepo", async () => {
     const dir = await writeFixture("monorepo-detect", {
       "package.json": JSON.stringify({ name: "test", workspaces: ["packages/*"] }),
@@ -495,5 +544,70 @@ describe("Framework Detection", async () => {
     assert.ok(project.workspaces.length >= 2);
     assert.ok(project.frameworks.includes("hono"));
     assert.equal(project.componentFramework, "react");
+  });
+});
+
+describe("Poetry Workspace Detection", async () => {
+  const mods = await loadModules();
+
+  it("detects FastAPI and SQLAlchemy from Poetry pyproject.toml in a declared workspace", async () => {
+    const dir = await writeFixture("python-custom-subdir-poetry-pyproject", {
+      "package.json": JSON.stringify({ name: "test", workspaces: ["apps/*", "services/*"] }),
+      "apps/web/package.json": JSON.stringify({ name: "@test/web", dependencies: { react: "^18.0.0" } }),
+      "services/custom-poetry-api/pyproject.toml": `[tool.poetry]
+name = "custom-poetry-api"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+fastapi = "^0.110.0"
+sqlalchemy = "^2.0.0"
+uvicorn = "^0.29.0"
+`,
+      "services/custom-poetry-api/main.py": `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/users")
+def create_user():
+    return {"created": True}
+`,
+      "services/custom-poetry-api/models.py": `from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True)
+    posts = relationship("Post")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    user = relationship("User")
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    assert.ok(project.frameworks.includes("fastapi"));
+    assert.ok(project.orms.includes("sqlalchemy"));
+    assert.ok(project.workspaces.some((w: any) => w.path === "services/custom-poetry-api"));
+    assert.ok(!project.workspaces.some((w: any) => w.path === "services"));
+
+    const files = await mods.collectFiles(dir);
+    const routes = await mods.detectRoutes(files, project);
+    const schemas = await mods.detectSchemas(files, project);
+    assert.ok(routes.some((r: any) => r.method === "GET" && r.path === "/health"));
+    assert.ok(routes.some((r: any) => r.method === "POST" && r.path === "/users"));
+    assert.ok(schemas.some((s: any) => s.name === "User"));
+    assert.ok(schemas.some((s: any) => s.name === "Post"));
   });
 });


### PR DESCRIPTION
## Summary

Fix Python framework detection for Poetry-managed projects that declare dependencies under `[tool.poetry.dependencies]` in `pyproject.toml`.

Previously, Codesight only parsed PEP 621-style `[project].dependencies` when reading `pyproject.toml`. That meant Poetry-based Python projects could miss framework and ORM detection even when dependencies like `Django`, `fastapi`, or `sqlalchemy` were present.

## Problem

For Poetry-managed projects, dependencies are commonly declared like this:

```toml
[tool.poetry.dependencies]
python = "^3.12"
Django = "^6.0"
```

Before this change, that section was ignored by `getPythonDeps()`, so framework detection could fall back incorrectly instead of recognizing the Python stack.

## Changes

### Scanner

Updated `src/scanner.ts` so `getPythonDeps()` now parses both:

- PEP 621 `[project].dependencies`
- Poetry `[tool.poetry.dependencies]`

The new parsing logic:

- skips the `python` runtime entry
- normalizes dependency names consistently with the existing Python dependency parsers
- preserves existing `requirements.txt` and `Pipfile` behavior

### Tests

Added regression coverage in `tests/detectors.test.ts` for:

- Django detection from root-level Poetry `pyproject.toml`
- ensuring dev-only Poetry groups do not trigger Django detection
- FastAPI + SQLAlchemy detection from Poetry `pyproject.toml` inside a declared workspace

This covers both direct project detection and nested workspace detection.

## Why This Fix

This is a targeted compatibility improvement for Poetry-managed Python projects without changing broader workspace or framework detection behavior.

It keeps the existing `pyproject.toml` parser path intact and adds support for the most common Poetry dependency section used in real projects.

## Validation

Ran locally:

```bash
pnpm test
```

Result:

- 34 tests passed
- 0 failed

Closes #18
