### PR TITLE
fix: use path.sep for wiki path-traversal check on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",
-    "test": "pnpm build && tsx --test tests/detectors.test.ts",
+    "test": "pnpm build && tsx --test tests/detectors.test.ts tests/wiki.test.ts",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/src/generators/wiki.ts
+++ b/src/generators/wiki.ts
@@ -601,11 +601,11 @@ export async function readWikiArticle(
   article: string
 ): Promise<string | null> {
   const { readFile } = await import("node:fs/promises");
-  const { resolve } = await import("node:path");
+  const { resolve, sep } = await import("node:path");
   const name = article.endsWith(".md") ? article : `${article}.md`;
   const wikiDir = resolve(outputDir, "wiki");
   const resolved = resolve(wikiDir, name);
-  if (!resolved.startsWith(wikiDir + "/") && resolved !== wikiDir) return null;
+  if (!resolved.startsWith(wikiDir + sep) && resolved !== wikiDir) return null;
   try {
     return await readFile(resolved, "utf-8");
   } catch {

--- a/tests/wiki.test.ts
+++ b/tests/wiki.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readWikiArticle } from "../dist/generators/wiki.js";
+
+async function createWikiFixture() {
+  const root = await mkdtemp(join(tmpdir(), "codesight-wiki-test-"));
+  const outputDir = join(root, ".codesight");
+  const wikiDir = join(outputDir, "wiki");
+  await mkdir(wikiDir, { recursive: true });
+  await writeFile(
+    join(wikiDir, "overview.md"),
+    "# Overview\n\nTest content for the wiki overview article.\n",
+    "utf-8"
+  );
+  await writeFile(
+    join(wikiDir, "index.md"),
+    "# Index\n\n- [Overview](./overview.md)\n",
+    "utf-8"
+  );
+  return { root, outputDir };
+}
+
+test("readWikiArticle returns content for an existing article (cross-platform path resolution)", async () => {
+  const { root, outputDir } = await createWikiFixture();
+  try {
+    const overview = await readWikiArticle(outputDir, "overview");
+    assert.notEqual(overview, null, "expected content for 'overview', got null");
+    assert.match(overview!, /Test content/);
+
+    // Should also accept the explicit .md extension
+    const overviewWithExt = await readWikiArticle(outputDir, "overview.md");
+    assert.notEqual(overviewWithExt, null);
+    assert.match(overviewWithExt!, /Test content/);
+
+    // Should also resolve index.md the same way
+    const index = await readWikiArticle(outputDir, "index");
+    assert.notEqual(index, null);
+    assert.match(index!, /Index/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("readWikiArticle rejects path-traversal attempts", async () => {
+  const { root, outputDir } = await createWikiFixture();
+  try {
+    const escaped1 = await readWikiArticle(outputDir, "../../../etc/passwd");
+    assert.equal(escaped1, null, "expected null for ../../../etc/passwd");
+
+    const escaped2 = await readWikiArticle(outputDir, "../package.json");
+    assert.equal(escaped2, null, "expected null for ../package.json");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("readWikiArticle returns null for nonexistent articles", async () => {
+  const { root, outputDir } = await createWikiFixture();
+  try {
+    const missing = await readWikiArticle(outputDir, "does-not-exist");
+    assert.equal(missing, null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

`readWikiArticle` hardcoded a POSIX forward-slash when verifying that the resolved article path stays inside the wiki directory:

```ts
if (!resolved.startsWith(wikiDir + "/") && resolved !== wikiDir) return null;
```

On Windows, `path.resolve()` returns backslash-delimited paths, so this check always returned `false` and every wiki article lookup fell through to `return null`. Both `codesight_get_wiki_index` and `codesight_get_wiki_article` MCP tools were broken for Windows users. Other tools (`codesight_get_summary`, `codesight_lint_wiki`, etc.) were unaffected because they don't route through `readWikiArticle`.

## Fix

Use `path.sep` so the boundary check works cross-platform:

```ts
const { resolve, sep } = await import("node:path");
...
if (!resolved.startsWith(wikiDir + sep) && resolved !== wikiDir) return null;
```

Two-line change in `src/generators/wiki.ts`.

## Tests

Added `tests/wiki.test.ts` with three regression tests:

- `readWikiArticle` returns content for an existing article (with and without `.md` extension, covering both `index` and a regular article)
- `readWikiArticle` rejects path-traversal attempts (`../../../etc/passwd`, `../package.json`)
- `readWikiArticle` returns `null` for nonexistent articles

Updated `package.json` test script to include the new file:

```
"test": "pnpm build && tsx --test tests/detectors.test.ts tests/wiki.test.ts"
```

All three new tests pass on Windows. Repro locally with `pnpm test`.

## Manual repro on Windows

1. `codesight scan` in any project
2. Call `codesight_get_wiki_index` via the MCP tool
3. **Before:** returns `null` (tool reports "wiki not found")
4. **After:** returns the index content

## Scope note

While running the suite I hit three pre-existing failures in `tests/detectors.test.ts` on `main` for Python workspace subdirectory detection. They are the same class of Windows path-separator issue but on the test-assertion side — they compare hardcoded `services/foo` strings against actual `services\foo` results. I deliberately left them out of this PR to keep it surgical and happy to send a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)