### PR TITLE
Fixing Golang based repos detection if there is also a package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,597 @@
+{
+  "name": "codesight",
+  "version": "1.12.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codesight",
+      "version": "1.12.2",
+      "license": "MIT",
+      "bin": {
+        "codesight": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/src/ast/extract-go.ts
+++ b/src/ast/extract-go.ts
@@ -348,6 +348,95 @@ export function extractGORMModelsStructured(
   return models;
 }
 
+// ─── Ent Schema Extraction ───
+
+export function extractEntSchemasStructured(
+  _filePath: string,
+  content: string
+): SchemaModel[] {
+  const models: SchemaModel[] = [];
+
+  const structPattern = /type\s+(\w+)\s+struct\s*\{\s*ent\.Schema\s*\}/g;
+  let structMatch;
+
+  while ((structMatch = structPattern.exec(content)) !== null) {
+    const name = structMatch[1];
+    const fields: SchemaField[] = [];
+    const relations: string[] = [];
+
+    const fieldsBlockMatch = content.match(
+      new RegExp(`func\\s*\\(${name}\\)\\s*Fields\\s*\\(\\)\\s*\\[\\]ent\\.Field\\s*\\{`)
+    );
+    if (fieldsBlockMatch && fieldsBlockMatch.index != null) {
+      const bodyStart = fieldsBlockMatch.index + fieldsBlockMatch[0].length;
+      const body = extractBraceBlock(content, bodyStart);
+      if (body) {
+        const fieldPattern = /field\.(\w+)\("(\w+)"\)/g;
+        let fm;
+        while ((fm = fieldPattern.exec(body)) !== null) {
+          const fieldType = fm[1].toLowerCase();
+          const fieldName = fm[2];
+          const lineEnd = body.indexOf("\n", fm.index);
+          const fieldLine = body.slice(fm.index, lineEnd > -1 ? lineEnd : undefined);
+
+          const flags: string[] = [];
+          if (fieldLine.includes(".Optional()")) flags.push("nullable");
+          if (fieldLine.includes(".Nillable()")) flags.push("nullable");
+          if (fieldLine.includes(".Unique()")) flags.push("unique");
+          if (fieldLine.includes(".Immutable()")) flags.push("immutable");
+          if (fieldLine.includes(".NotEmpty()")) flags.push("required");
+          if (fieldLine.includes(".Default(")) flags.push("default");
+          if (fieldLine.includes(".Positive()")) flags.push("positive");
+
+          fields.push({ name: fieldName, type: fieldType, flags });
+        }
+
+        const enumFieldPattern = /field\.Enum\("(\w+)"\)\.\s*Values\(([^)]+)\)/g;
+        let em;
+        while ((em = enumFieldPattern.exec(body)) !== null) {
+          const fieldName = em[1];
+          const lineEnd = body.indexOf("\n", em.index);
+          const fieldLine = body.slice(em.index, lineEnd > -1 ? lineEnd : undefined);
+          const flags: string[] = [];
+          if (fieldLine.includes(".Default(")) flags.push("default");
+          if (fieldLine.includes(".Optional()")) flags.push("nullable");
+          fields.push({ name: fieldName, type: "enum", flags });
+        }
+      }
+    }
+
+    const edgesBlockMatch = content.match(
+      new RegExp(`func\\s*\\(${name}\\)\\s*Edges\\s*\\(\\)\\s*\\[\\]ent\\.Edge\\s*\\{`)
+    );
+    if (edgesBlockMatch && edgesBlockMatch.index != null) {
+      const bodyStart = edgesBlockMatch.index + edgesBlockMatch[0].length;
+      const body = extractBraceBlock(content, bodyStart);
+      if (body) {
+        const edgePattern = /edge\.(To|From)\("(\w+)",\s*(\w+)\.Type\)/g;
+        let edgeMatch;
+        while ((edgeMatch = edgePattern.exec(body)) !== null) {
+          const direction = edgeMatch[1].toLowerCase();
+          const edgeName = edgeMatch[2];
+          const targetType = edgeMatch[3];
+          relations.push(`${edgeName} → ${targetType} (${direction})`);
+        }
+      }
+    }
+
+    if (fields.length > 0 || relations.length > 0) {
+      models.push({
+        name,
+        fields,
+        relations,
+        orm: "ent" as any,
+        confidence: "ast",
+      });
+    }
+  }
+
+  return models;
+}
+
 // ─── Helpers ───
 
 /**

--- a/src/detectors/schema.ts
+++ b/src/detectors/schema.ts
@@ -3,7 +3,7 @@ import { readFileSafe } from "../scanner.js";
 import { loadTypeScript } from "../ast/loader.js";
 import { extractDrizzleSchemaAST, extractTypeORMSchemaAST } from "../ast/extract-schema.js";
 import { extractSQLAlchemyAST, extractDjangoModelsAST, extractSQLModelAST } from "../ast/extract-python.js";
-import { extractGORMModelsStructured } from "../ast/extract-go.js";
+import { extractGORMModelsStructured, extractEntSchemasStructured } from "../ast/extract-go.js";
 import { extractEloquentModels } from "../ast/extract-php.js";
 import { extractEntityFrameworkModels } from "../ast/extract-csharp.js";
 import { extractRoomEntities } from "../ast/extract-android.js";
@@ -40,6 +40,9 @@ export async function detectSchemas(
         break;
       case "gorm":
         models.push(...(await detectGORMSchemas(files, project)));
+        break;
+      case "ent":
+        models.push(...(await detectEntSchemas(files, project)));
         break;
       case "activerecord":
         models.push(...(await detectActiveRecordSchemas(project)));
@@ -440,6 +443,28 @@ async function detectGORMSchemas(
 
     const rel = relative(_project.root, file);
     const structModels = extractGORMModelsStructured(rel, content);
+    models.push(...structModels);
+  }
+
+  return models;
+}
+
+// --- Ent (Go) ---
+async function detectEntSchemas(
+  files: string[],
+  _project: ProjectInfo
+): Promise<SchemaModel[]> {
+  const goFiles = files.filter(
+    (f) => f.endsWith(".go") && (f.includes("/ent/schema/") || f.includes("/schema/"))
+  );
+  const models: SchemaModel[] = [];
+
+  for (const file of goFiles) {
+    const content = await readFileSafe(file);
+    if (!content.includes("ent.Schema")) continue;
+
+    const rel = relative(_project.root, file);
+    const structModels = extractEntSchemasStructured(rel, content);
     models.push(...structModels);
   }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -262,6 +262,7 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
       laravel: "php", php: "php",
       actix: "rust", axum: "rust",
       aspnet: "csharp",
+      gin: "go", fiber: "go", echo: "go", chi: "go", "go-net-http": "go",
     };
     const wsLangs = new Set<string>();
     if (language === "typescript" || language === "javascript" || allDeps["react"] || allDeps["typescript"]) {
@@ -271,8 +272,25 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
       const l = FW_LANG[fw];
       if (l) wsLangs.add(l);
     }
-    if (wsLangs.size > 1) language = "mixed";
-    else if (wsLangs.size === 1) language = wsLangs.values().next().value as typeof language;
+    if (wsLangs.size > 1) {
+      if (language !== "mixed" && language !== "javascript" && wsLangs.has(language)) {
+        // detectLanguage already resolved a primary language — keep it
+      } else {
+        language = "mixed";
+      }
+    } else if (wsLangs.size === 1) {
+      language = wsLangs.values().next().value as typeof language;
+    }
+  }
+
+  const jsOnlyFrameworks = new Set<Framework>([
+    "next-app", "next-pages", "hono", "express", "fastify", "koa",
+    "nestjs", "elysia", "adonis", "trpc", "sveltekit", "remix", "nuxt",
+    "raw-http", "angular",
+  ]);
+  const nonJSLangs = new Set(["go", "python", "ruby", "elixir", "java", "kotlin", "rust", "php", "dart", "swift", "csharp"]);
+  if (nonJSLangs.has(language) && frameworks.some((f) => !jsOnlyFrameworks.has(f))) {
+    frameworks = frameworks.filter((f) => !jsOnlyFrameworks.has(f));
   }
 
   return {
@@ -420,13 +438,23 @@ async function detectFrameworks(
   if (pyDeps.includes("fastapi")) frameworks.push("fastapi");
   if (pyDeps.includes("django")) frameworks.push("django");
 
-  // Go frameworks - check go.mod
+  // Go frameworks — require both go.mod dep AND actual import in .go source files.
+  // A dep in go.mod may be transitive or used only for utilities (e.g. go-chi/cors
+  // without chi as a router), so we verify with a quick import grep.
   const goDeps = await getGoDeps(root);
+  const goFwCandidates: { dep: string; importStr: string; fw: Framework }[] = [
+    { dep: "gin-gonic/gin", importStr: `"github.com/gin-gonic/gin"`, fw: "gin" },
+    { dep: "gofiber/fiber", importStr: `"github.com/gofiber/fiber`, fw: "fiber" },
+    { dep: "labstack/echo", importStr: `"github.com/labstack/echo`, fw: "echo" },
+    { dep: "go-chi/chi", importStr: `"github.com/go-chi/chi`, fw: "chi" },
+  ];
+  for (const candidate of goFwCandidates) {
+    if (!goDeps.some((d) => d.includes(candidate.dep))) continue;
+    if (await goImportUsed(root, candidate.importStr)) {
+      frameworks.push(candidate.fw);
+    }
+  }
   if (goDeps.some((d) => d.includes("net/http"))) frameworks.push("go-net-http");
-  if (goDeps.some((d) => d.includes("gin-gonic/gin"))) frameworks.push("gin");
-  if (goDeps.some((d) => d.includes("gofiber/fiber"))) frameworks.push("fiber");
-  if (goDeps.some((d) => d.includes("labstack/echo"))) frameworks.push("echo");
-  if (goDeps.some((d) => d.includes("go-chi/chi"))) frameworks.push("chi");
 
   // Ruby on Rails
   const hasGemfile = await fileExists(join(root, "Gemfile"));
@@ -597,6 +625,7 @@ async function detectORMs(
 
   const goDeps = await getGoDeps(root);
   if (goDeps.some((d) => d.includes("gorm"))) orms.push("gorm");
+  if (goDeps.some((d) => d.includes("entgo.io/ent"))) orms.push("ent");
 
   // Rails ActiveRecord
   const hasGemfile = await fileExists(join(root, "Gemfile"));
@@ -711,7 +740,14 @@ async function detectLanguage(
   if (hasPackageSwift) langs.push("swift");
   if (hasCsproj) langs.push("csharp");
 
-  if (langs.length > 1) return "mixed";
+  if (langs.length > 1) {
+    const primaryManifests: string[] = [
+      "go", "rust", "ruby", "elixir", "swift", "dart", "csharp", "java", "kotlin", "php", "python",
+    ];
+    const primary = langs.filter((l) => primaryManifests.includes(l));
+    if (primary.length === 1) return primary[0] as any;
+    return "mixed";
+  }
   if (langs.length === 1) return langs[0] as any;
 
   // Fallback: detect by file extensions present in root
@@ -855,7 +891,7 @@ async function detectNonJSWorkspace(
     } catch {}
   }
 
-  // Go web frameworks (workspace-level)
+  // Go web frameworks and ORMs (workspace-level)
   const goModPath = join(wsPath, "go.mod");
   if (await fileExists(goModPath)) {
     try {
@@ -865,6 +901,8 @@ async function detectNonJSWorkspace(
       else if (goMod.includes("labstack/echo")) frameworks.push("echo");
       else if (goMod.includes("go-chi/chi")) frameworks.push("chi");
       else frameworks.push("go-net-http");
+      if (goMod.includes("gorm")) orms.push("gorm");
+      if (goMod.includes("entgo.io/ent")) orms.push("ent");
     } catch {}
   }
 
@@ -1046,11 +1084,31 @@ function addPythonDep(rawName: string, deps: string[]): void {
   deps.push(name);
 }
 
-async function getGoDeps(root: string): Promise<string[]> {
+async function goImportUsed(root: string, importStr: string): Promise<boolean> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === "vendor" || entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      const fullPath = join(root, entry.name);
+      if (entry.isDirectory()) {
+        if (await goImportUsed(fullPath, importStr)) return true;
+      } else if (entry.name.endsWith(".go")) {
+        try {
+          const content = await readFile(fullPath, "utf-8");
+          if (content.includes(importStr)) return true;
+        } catch {}
+      }
+    }
+  } catch {}
+  return false;
+}
+
+async function getGoDeps(root: string, includeIndirect = false): Promise<string[]> {
   const deps: string[] = [];
   try {
     const gomod = await readFile(join(root, "go.mod"), "utf-8");
     for (const line of gomod.split("\n")) {
+      if (!includeIndirect && line.includes("// indirect")) continue;
       // Block format:  \t github.com/pkg/name v1.2.3
       let match = line.match(/^\s+([\w./-]+)\s+v/);
       if (!match) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export type Framework =
   | "angular"
   | "unknown";
 
-export type ORM = "drizzle" | "prisma" | "typeorm" | "sqlalchemy" | "django" | "gorm" | "mongoose" | "sequelize" | "activerecord" | "ecto" | "eloquent" | "entity-framework" | "exposed" | "room" | "unknown";
+export type ORM = "drizzle" | "prisma" | "typeorm" | "sqlalchemy" | "django" | "gorm" | "ent" | "mongoose" | "sequelize" | "activerecord" | "ecto" | "eloquent" | "entity-framework" | "exposed" | "room" | "unknown";
 
 export type ComponentFramework = "react" | "vue" | "svelte" | "flutter" | "jetpack-compose" | "angular" | "unknown";
 


### PR DESCRIPTION
## Add Go Ent ORM support and fix language detection for Go-primary projects

### Problem

When scanning a Go monorepo that also has a `package.json` (for auxiliary JS/TS tooling like SDKs or health checks), codesight would:

1. **Report the language as `typescript`** — even when `go.mod` is at root and 99% of the codebase is Go
2. **Detect no ORM** — Ent (entgo.io/ent) is a widely-used Go ORM with 15k+ GitHub stars, but wasn't in codesight's supported list
3. **List JS frameworks alongside Go frameworks** — e.g. `gin, fiber, chi, express` when `express` is only from a small SDK workspace
4. **False-positive Go framework detection** — listing `gin`, `chi`, etc. from `go.mod` even when those packages aren't actually imported in source files (transitive deps or utility-only packages like `go-chi/cors`)

### Changes

#### Language detection (`scanner.ts` — `detectLanguage`)
- When multiple language manifests are detected (e.g. `go.mod` + `tsconfig.json`), native-language manifests (Go, Rust, Ruby, etc.) now take priority over TypeScript/JavaScript. A `tsconfig.json` alongside `go.mod` is almost always for auxiliary tooling (CI checks, SDKs), not the primary application.
- The multi-workspace language override now respects the primary language from `detectLanguage` instead of blindly resetting to `mixed`.

#### Go framework language mapping (`scanner.ts` — `FW_LANG`)
- Added `gin`, `fiber`, `echo`, `chi`, and `go-net-http` → `"go"` to the `FW_LANG` map so multi-workspace language inference correctly identifies Go backends.

#### Go framework detection accuracy (`scanner.ts` — `detectFrameworks`)
- Framework detection now verifies that a Go framework package is **actually imported in source files**, not just present in `go.mod`. This prevents false positives from transitive deps or utility packages (e.g. `go-chi/cors` without using chi as a router).
- Added `goImportUsed()` helper that does a recursive file walk to check for actual import statements.
- `getGoDeps()` now skips `// indirect` dependencies by default.

#### JS framework filtering (`scanner.ts` — `detectProject`)
- When the primary language is a non-JS language (Go, Python, Ruby, etc.), JS-only frameworks from auxiliary workspaces are filtered from the framework list. This prevents confusing output like `gin, fiber, express` when `express` comes from a small SDK workspace.

#### Ent ORM support (new)
- **`types.ts`**: Added `"ent"` to the `ORM` type union.
- **`scanner.ts`**: Detects `entgo.io/ent` in `go.mod` at both root and workspace level.
- **`ast/extract-go.ts`**: New `extractEntSchemasStructured()` function that parses Ent schema files by:
  - Finding structs embedding `ent.Schema`
  - Extracting fields from `Fields()` methods (`field.String`, `field.Int`, `field.Enum`, etc.) with flags (Optional, Unique, Immutable, Default, etc.)
  - Extracting relationships from `Edges()` methods (`edge.To`, `edge.From`)
- **`detectors/schema.ts`**: Added `case "ent"` dispatch and `detectEntSchemas()` function targeting `ent/schema/` paths.

### Before / After

Tested on a production Go monorepo (5200 files, Fiber + Ent, with a small TypeScript SDK workspace):

| | Before | After |
|---|---|---|
| Language | `typescript` | `go` |
| Frameworks | `gin, fiber, chi, express` | `gin, fiber, chi` |
| ORM | _(none)_ | `ent` |
| Schema models | 0 | 503 |

Fixes #28 