### PR TITLE
feat: add celery as events framework captured by regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ The 1.3x multiplier accounts for AI revisiting files during multi-turn conversat
 
 | Category | Supported |
 |---|---|
-| **Routes** | Hono, Express, Fastify, Next.js (App + Pages), Koa, NestJS, tRPC, Elysia, AdonisJS, SvelteKit, Remix, Nuxt, FastAPI, Flask, Django, Go (net/http, Gin, Fiber, Echo, Chi), Rails, Phoenix, Spring Boot, Ktor, Actix, Axum, Laravel, ASP.NET Core (controllers + minimal API), Vapor, Flutter (go_router), raw http.createServer |
+| **Routes** | Hono, Express, Fastify, Next.js (App + Pages), Koa, NestJS, tRPC, Elysia, AdonisJS, SvelteKit, Remix, Nuxt, FastAPI, Flask, Django, Celery, Go (net/http, Gin, Fiber, Echo, Chi), Rails, Phoenix, Spring Boot, Ktor, Actix, Axum, Laravel, ASP.NET Core (controllers + minimal API), Vapor, Flutter (go_router), raw http.createServer |
 | **Schema** | Drizzle, Prisma, TypeORM, Mongoose, Sequelize, SQLAlchemy, Django ORM, ActiveRecord, Ecto, Eloquent, Entity Framework, Exposed (13 ORMs) |
 | **Components** | React, Vue, Svelte, Flutter widgets (StatelessWidget, StatefulWidget, ConsumerWidget), SwiftUI views (auto-filters shadcn/ui and Radix primitives) |
 | **Libraries** | TypeScript, JavaScript, Python, Go, Dart, Swift, C#, PHP (exports with function signatures) |
@@ -563,7 +563,7 @@ startup_timeout_sec = 60
 | `codesight_get_blast_radius` | Impact analysis before changing a file |
 | `codesight_get_env` | Environment variables (filter: required only) |
 | `codesight_get_hot_files` | Most imported files with configurable limit |
-| `codesight_get_events` | Background events: BullMQ queues, Kafka topics, Redis pub/sub, EventEmitter |
+| `codesight_get_events` | Background events: BullMQ queues, Celery tasks, Kafka topics, Redis pub/sub, EventEmitter |
 | `codesight_get_coverage` | Test coverage map: which routes and models have test files |
 | `codesight_refresh` | Force re-scan (results are cached per session) |
 

--- a/src/detectors/events.ts
+++ b/src/detectors/events.ts
@@ -90,14 +90,23 @@ export async function detectEvents(
       }
     }
 
-    // Python Celery: @app.task / @shared_task + apply_async('task-name')
+    // Python Celery task definitions
     if (file.endsWith(".py") && (content.includes("celery") || content.includes("Celery"))) {
-      const celeryTaskPat = /@(?:app\.task|shared_task|celery\.task)[\s\S]{0,100}def\s+(\w+)/g;
-      while ((m = celeryTaskPat.exec(content)) !== null) {
+      const moduleName = rel.endsWith("/__init__.py")
+        ? rel.slice(0, -"/__init__.py".length).replace(/\//g, ".")
+        : rel.replace(/\.py$/, "").replace(/\//g, ".");
+      const celeryTaskPat =
+        /@(?:(?:\w+)\.task|shared_task)\s*(?:\(([\s\S]{0,300}?)\))?\s*\n\s*def\s+(\w+)/g;
+      let celeryMatch: RegExpExecArray | null;
+
+      while ((celeryMatch = celeryTaskPat.exec(content)) !== null) {
+        const decoratorArgs = celeryMatch[1] || "";
+        const functionName = celeryMatch[2];
+        const explicitName = decoratorArgs.match(/\bname\s*=\s*["']([^"']+)["']/)?.[1];
         events.push({
-          name: m[1],
+          name: explicitName || `${moduleName}.${functionName}`,
           type: "queue",
-          system: "bullmq", // map to closest JS equivalent concept for display
+          system: "celery",
           file: rel,
           payloadType: "celery-task",
         });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -357,7 +357,7 @@ async function toolGetEvents(args: any): Promise<string> {
   const result = await getScanResult(args.directory);
   const events = result.events;
   if (!events || events.length === 0) {
-    return "No async events or queues detected. Events are auto-detected from BullMQ, Kafka, Redis pub/sub, Socket.io, and EventEmitter usage.";
+    return "No async events or queues detected. Events are auto-detected from BullMQ, Celery, Kafka, Redis pub/sub, Socket.io, and EventEmitter usage.";
   }
 
   let filtered = events;
@@ -593,7 +593,7 @@ const TOOLS = [
       type: "object",
       properties: {
         directory: { type: "string", description: "Directory (defaults to cwd)" },
-        system: { type: "string", description: "Filter by system: bullmq | kafka | redis-pub-sub | socket.io | eventemitter" },
+        system: { type: "string", description: "Filter by system: bullmq | celery | kafka | redis-pub-sub | socket.io | eventemitter" },
       },
     },
     handler: toolGetEvents,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -257,7 +257,7 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
     const FW_LANG: Partial<Record<string, string>> = {
       vapor: "swift", swiftui: "swift",
       flutter: "dart",
-      django: "python", flask: "python", fastapi: "python",
+      django: "python", flask: "python", fastapi: "python", celery: "python",
       rails: "ruby",
       phoenix: "elixir",
       spring: "java",
@@ -479,6 +479,7 @@ async function detectFrameworks(
   if (pyDeps.includes("flask")) frameworks.push("flask");
   if (pyDeps.includes("fastapi")) frameworks.push("fastapi");
   if (pyDeps.includes("django")) frameworks.push("django");
+  if (pyDeps.includes("celery")) frameworks.push("celery");
 
   // Go frameworks — require both go.mod dep AND actual import in .go source files.
   // A dep in go.mod may be transitive or used only for utilities (e.g. go-chi/cors
@@ -911,6 +912,7 @@ async function detectNonJSWorkspace(
       frameworks.push("django");
       orms.push("django");
     }
+    if (pyDeps.includes("celery")) frameworks.push("celery");
   } catch {}
 
   // Elixir / Phoenix / Ecto (workspace-level; mirrors existing root-level detection)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export type Framework =
   | "flask"
   | "fastapi"
   | "django"
+  | "celery"
   | "go-net-http"
   | "gin"
   | "fiber"
@@ -239,7 +240,7 @@ export interface PluginDetectorResult {
 export interface EventInfo {
   name: string;
   type: "queue" | "topic" | "event" | "channel";
-  system: "bullmq" | "kafka" | "redis-pub-sub" | "socket.io" | "eventemitter" | "unknown";
+  system: "bullmq" | "kafka" | "redis-pub-sub" | "socket.io" | "eventemitter" | "celery" | "unknown";
   file: string;
   payloadType?: string;
 }

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -22,12 +22,13 @@ async function loadModules() {
   const { collectFiles, detectProject } = await import("../dist/scanner.js");
   const { detectRoutes } = await import("../dist/detectors/routes.js");
   const { detectSchemas } = await import("../dist/detectors/schema.js");
+  const { detectEvents } = await import("../dist/detectors/events.js");
   const { detectComponents } = await import("../dist/detectors/components.js");
   const { detectDependencyGraph } = await import("../dist/detectors/graph.js");
   const { detectMiddleware } = await import("../dist/detectors/middleware.js");
   const { detectConfig } = await import("../dist/detectors/config.js");
   const { detectLibs } = await import("../dist/detectors/libs.js");
-  return { collectFiles, detectProject, detectRoutes, detectSchemas, detectComponents, detectDependencyGraph, detectMiddleware, detectConfig, detectLibs };
+  return { collectFiles, detectProject, detectRoutes, detectSchemas, detectEvents, detectComponents, detectDependencyGraph, detectMiddleware, detectConfig, detectLibs };
 }
 
 async function assertFastApiSqlAlchemyDetection(mods: any, dir: string, workspacePath: string, forbiddenWorkspacePaths: string[] = []) {
@@ -513,6 +514,36 @@ describe("Framework Detection", async () => {
     assert.ok(project.frameworks.includes("elysia"));
   });
 
+  it("detects Celery framework from requirements.txt", async () => {
+    const dir = await writeFixture("celery-detect", {
+      "requirements.txt": "celery\nredis\n",
+      "tasks.py": `from celery import Celery
+app = Celery("worker")
+
+@app.task
+def ping():
+    return "pong"
+`,
+    });
+    const project = await mods.detectProject(dir);
+    assert.ok(project.frameworks.includes("celery"));
+    assert.equal(project.language, "python");
+  });
+
+  it("detects Celery framework from pyproject.toml", async () => {
+    const dir = await writeFixture("celery-pyproject-detect", {
+      "pyproject.toml": `[project]
+name = "celery-worker"
+dependencies = [
+  "celery>=5.4.0",
+  "redis>=5.0.0",
+]
+`,
+    });
+    const project = await mods.detectProject(dir);
+    assert.ok(project.frameworks.includes("celery"));
+  });
+
   it("detects monorepo", async () => {
     const dir = await writeFixture("monorepo-detect", {
       "package.json": JSON.stringify({ name: "test", workspaces: ["packages/*"] }),
@@ -525,6 +556,39 @@ describe("Framework Detection", async () => {
     assert.ok(project.workspaces.length >= 2);
     assert.ok(project.frameworks.includes("hono"));
     assert.equal(project.componentFramework, "react");
+  });
+});
+
+describe("Event Detection", async () => {
+  const mods = await loadModules();
+
+  it("detects Celery task definitions", async () => {
+    const dir = await writeFixture("celery-events", {
+      "requirements.txt": "celery\n",
+      "tasks.py": `from celery import Celery, shared_task
+app = Celery("worker")
+
+@app.task
+def add(x, y):
+    return x + y
+
+@shared_task
+def cleanup():
+    return True
+
+@app.task(bind=True, name="billing.report_usage_to_stripe", max_retries=3)
+def report_usage_to_stripe_task(self):
+    return None
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    const files = await mods.collectFiles(dir);
+    const events = await mods.detectEvents(files, project);
+
+    assert.ok(events.some((e: any) => e.system === "celery" && e.name === "tasks.add" && e.payloadType === "celery-task"));
+    assert.ok(events.some((e: any) => e.system === "celery" && e.name === "tasks.cleanup" && e.payloadType === "celery-task"));
+    assert.ok(events.some((e: any) => e.system === "celery" && e.name === "billing.report_usage_to_stripe" && e.payloadType === "celery-task"));
   });
 });
 
@@ -746,5 +810,26 @@ class Post(Base):
     });
 
     await assertFastApiSqlAlchemyDetection(mods, dir, "container-dir/custom-python-backend", ["container-dir"]);
+  });
+
+  it("detects Celery in a custom-named services workspace", async () => {
+    const dir = await writeFixture("python-celery-workspace", {
+      "package.json": JSON.stringify({ name: "test", workspaces: ["apps/*", "services/*"] }),
+      "apps/web/package.json": JSON.stringify({ name: "@test/web", dependencies: { react: "^18.0.0" } }),
+      "services/worker-service/requirements.txt": "celery\nredis\n",
+      "services/worker-service/tasks.py": `from celery import Celery
+app = Celery("worker")
+
+@app.task
+def sync_users():
+    return True
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    const workspace = project.workspaces.find((w: any) => w.path === "services/worker-service");
+    assert.ok(project.frameworks.includes("celery"), `Expected celery in frameworks, got ${project.frameworks.join(", ")}`);
+    assert.ok(workspace, `Expected workspace services/worker-service, got ${project.workspaces.map((w: any) => w.path).join(", ")}`);
+    assert.ok(workspace.frameworks.includes("celery"), `Expected celery in workspace frameworks, got ${workspace.frameworks.join(", ")}`);
   });
 });


### PR DESCRIPTION
Hi, love the project.

I use Celery as an events framework and added it to the regex searches in events.ts and the README.md. The test passes and it works on my Celery app. However, I did not benchmark it as I'm not sure exactly how you were doing this and my Celery app is not open-source.

I can make any changes if requested or you can.