### PR TITLE
Adds roku (Brightscript/BrighterScript and SceneGraph) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,36 +489,71 @@ The 1.3x multiplier accounts for AI revisiting files during multi-turn conversat
 
 ## Roku / BrightScript / SceneGraph
 
-codesight treats Roku channels as first-class projects. The `manifest` file at the channel root anchors detection; multi-creator monorepos with channels under `src/apps/<creator>/` are picked up as separate workspaces.
+codesight treats Roku channels as first-class projects. The `manifest` file at the channel root anchors detection — the same file Roku itself uses to identify a channel, so zero configuration is needed for the common case.
 
-Mappings to codesight's data model:
+**Standard single-channel layout** (about 90% of Roku repos, matches the Roku docs' getting-started template and projects like `rokucommunity/brighterscript-template`):
+
+```
+/
+  manifest
+  source/         # Main.brs + shared .brs libraries
+  components/     # *.xml + paired *.brs component handlers
+  images/
+```
+
+codesight also recognizes the `rokucommunity/brighterscript-template` layout where the channel lives under `src/` and the root carries a `bsconfig.json` for BrighterScript tooling.
+
+**Multi-channel monorepo layout** (less common — used by larger codebases that ship several branded channels from one repo with `roku-deploy` + `gulp` to merge a shared `common/` layer with per-channel assets at build time):
+
+```
+/
+  package.json      # depends on roku-deploy, gulp
+  gulpfile.js
+  src/apps/
+    common/         # shared layer, merged into every channel at build
+    creatorA/
+      manifest
+    creatorB/
+      manifest
+```
+
+This is detected via a strict structural signal: no manifest at root, `roku-deploy` in deps, and a `common/` directory with at least 2 sibling directories that each have their own `manifest`. When the signal matches, each channel (plus `common/`) is registered as a workspace.
+
+### Mappings to codesight's data model
 
 | codesight concept | Roku equivalent |
 |---|---|
-| Routes | Screens — each `ShowScreen(m.xxxView, modal?)` call-site in a Scene's `.brs`, resolved to the XML component that implements the view. `method = VIEW` or `MODAL`. |
+| Routes | Screens — every child element with an `id` declared in the Scene XML's `<children>`. `method = VIEW` by default, upgraded to `MODAL` if a navigation call-site passes a literal `true` as the second argument. |
 | Schema | Every SceneGraph component XML whose `<interface>` has at least one `<field>` — the typed contract is the model. |
 | Components | Every `<component name="..." extends="...">` XML (views, tasks, scenes, modals). Props = interface fields. |
-| Libraries | `.brs` / `.bs` files under `source/` — top-level `function`/`sub` plus BrighterScript `class` / `namespace` / `enum` / `interface`. |
-| Middleware | `observeField` subscriptions, `m.global.AddField` registrations, BugsnagTask, RudderstackTask. |
+| Libraries | `.brs` / `.bs` files outside `components/` — top-level `function`/`sub` plus BrighterScript `class` / `namespace` / `enum` / `interface`. |
+| Middleware | `observeField` subscriptions, `m.global.AddField` registrations. BugsnagTask / RudderstackTask recognized when present. |
 | Dependencies | `<script uri="pkg:/..." />` includes in component XML + `import "pkg:/..."` in `.bs`. |
 | Events | Observed fields (`system: scenegraph-observer`) and Rudderstack event names (`system: rudderstack`). |
-| Config | The Roku `manifest` key/value lines plus `appConfig.brs` upper-case constants. |
+| Config | The Roku `manifest` key/value lines surfaced as `manifest.<name>` pseudo env-vars. |
 
-Example output for a Roku channel:
+### Configurable navigation helpers
+
+Many Roku projects use a custom helper to switch the visible screen (names vary: `ShowScreen`, `pushScreen`, `NavigateTo`, `showView`, etc.). These are used as optional enrichment to tag routes as `MODAL`. Defaults cover the common conventions; override with `rokuScreenHelpers` in your codesight config if your project uses a different name:
+
+```json
+{
+  "rokuScreenHelpers": ["Router.push", "openScreen"]
+}
+```
+
+Routes are still detected from `<children>` even when no helper is present or when no call-site matches.
+
+### Example output
 
 ```markdown
-- `VIEW` `/homeView` [db] — src/apps/common/components/views/HomeView.xml
-- `VIEW` `/loginView` [auth] — src/apps/common/components/views/LoginView.xml
-- `MODAL` `/errorModal` — src/apps/common/components/views/ErrorModal.xml
+- `VIEW` `/homeView` — components/views/HomeView.xml
+- `VIEW` `/detailView` — components/views/DetailView.xml
+- `MODAL` `/errorModal` — components/modals/ErrorModal.xml
 
-### PageContainerTask
+### DataTask
 - requestUrl: string
-- channelID: string
-- pageID: string
-- language: string
-- pageResponse: node-ref
-- token: string
-- languageManifest: object
+- response: object
 ```
 
 ## Supported Stacks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Zero dependencies. AST precision. 30+ framework detectors. 13 ORM parsers. 13 MCP tools. One `npx` call.**
 
-**Works with TypeScript, JavaScript, Python, Go, Ruby, Elixir, Java, Kotlin, Rust, PHP, Dart, Swift, and C#.** TypeScript projects get full AST precision. Everything else uses battle-tested regex detection across the same 30+ frameworks.
+**Works with TypeScript, JavaScript, Python, Go, Ruby, Elixir, Java, Kotlin, Rust, PHP, Dart, Swift, C#, and BrightScript/BrighterScript (Roku).** TypeScript projects get full AST precision. Everything else uses battle-tested regex detection across the same 30+ frameworks.
 
 [![npm version](https://img.shields.io/npm/v/codesight?style=for-the-badge&logo=npm&color=CB3837)](https://www.npmjs.com/package/codesight)
 [![npm downloads](https://img.shields.io/npm/dm/codesight?style=for-the-badge&logo=npm&color=blue&label=Monthly%20Downloads)](https://www.npmjs.com/package/codesight)
@@ -487,19 +487,53 @@ Each detector type maps to a measured token cost that an AI would spend to disco
 
 The 1.3x multiplier accounts for AI revisiting files during multi-turn conversations. These estimates are conservative. A developer manually verified that Claude Code spends 40-70K tokens exploring the same projects that codesight summarizes in 3-5K tokens.
 
+## Roku / BrightScript / SceneGraph
+
+codesight treats Roku channels as first-class projects. The `manifest` file at the channel root anchors detection; multi-creator monorepos with channels under `src/apps/<creator>/` are picked up as separate workspaces.
+
+Mappings to codesight's data model:
+
+| codesight concept | Roku equivalent |
+|---|---|
+| Routes | Screens — each `ShowScreen(m.xxxView, modal?)` call-site in a Scene's `.brs`, resolved to the XML component that implements the view. `method = VIEW` or `MODAL`. |
+| Schema | Every SceneGraph component XML whose `<interface>` has at least one `<field>` — the typed contract is the model. |
+| Components | Every `<component name="..." extends="...">` XML (views, tasks, scenes, modals). Props = interface fields. |
+| Libraries | `.brs` / `.bs` files under `source/` — top-level `function`/`sub` plus BrighterScript `class` / `namespace` / `enum` / `interface`. |
+| Middleware | `observeField` subscriptions, `m.global.AddField` registrations, BugsnagTask, RudderstackTask. |
+| Dependencies | `<script uri="pkg:/..." />` includes in component XML + `import "pkg:/..."` in `.bs`. |
+| Events | Observed fields (`system: scenegraph-observer`) and Rudderstack event names (`system: rudderstack`). |
+| Config | The Roku `manifest` key/value lines plus `appConfig.brs` upper-case constants. |
+
+Example output for a Roku channel:
+
+```markdown
+- `VIEW` `/homeView` [db] — src/apps/common/components/views/HomeView.xml
+- `VIEW` `/loginView` [auth] — src/apps/common/components/views/LoginView.xml
+- `MODAL` `/errorModal` — src/apps/common/components/views/ErrorModal.xml
+
+### PageContainerTask
+- requestUrl: string
+- channelID: string
+- pageID: string
+- language: string
+- pageResponse: node-ref
+- token: string
+- languageManifest: object
+```
+
 ## Supported Stacks
 
 | Category | Supported |
 |---|---|
-| **Routes** | Hono, Express, Fastify, Next.js (App + Pages), Koa, NestJS, tRPC, Elysia, AdonisJS, SvelteKit, Remix, Nuxt, FastAPI, Flask, Django, Go (net/http, Gin, Fiber, Echo, Chi), Rails, Phoenix, Spring Boot, Ktor, Actix, Axum, Laravel, ASP.NET Core (controllers + minimal API), Vapor, Flutter (go_router), raw http.createServer |
-| **Schema** | Drizzle, Prisma, TypeORM, Mongoose, Sequelize, SQLAlchemy, Django ORM, ActiveRecord, Ecto, Eloquent, Entity Framework, Exposed (13 ORMs) |
-| **Components** | React, Vue, Svelte, Flutter widgets (StatelessWidget, StatefulWidget, ConsumerWidget), SwiftUI views (auto-filters shadcn/ui and Radix primitives) |
-| **Libraries** | TypeScript, JavaScript, Python, Go, Dart, Swift, C#, PHP (exports with function signatures) |
-| **Middleware** | Auth, rate limiting, CORS, validation, logging, error handlers |
-| **Dependencies** | Import graph with hot file detection (most imported = highest blast radius) |
+| **Routes** | Hono, Express, Fastify, Next.js (App + Pages), Koa, NestJS, tRPC, Elysia, AdonisJS, SvelteKit, Remix, Nuxt, FastAPI, Flask, Django, Go (net/http, Gin, Fiber, Echo, Chi), Rails, Phoenix, Spring Boot, Ktor, Actix, Axum, Laravel, ASP.NET Core (controllers + minimal API), Vapor, Flutter (go_router), Roku SceneGraph (screens via ShowScreen), raw http.createServer |
+| **Schema** | Drizzle, Prisma, TypeORM, Mongoose, Sequelize, SQLAlchemy, Django ORM, ActiveRecord, Ecto, Eloquent, Entity Framework, Exposed, Room, SceneGraph `<interface>` contracts (14 ORMs) |
+| **Components** | React, Vue, Svelte, Flutter widgets (StatelessWidget, StatefulWidget, ConsumerWidget), SwiftUI views (auto-filters shadcn/ui and Radix primitives), Roku SceneGraph components |
+| **Libraries** | TypeScript, JavaScript, Python, Go, Dart, Swift, C#, PHP, BrightScript, BrighterScript (exports with function signatures) |
+| **Middleware** | Auth, rate limiting, CORS, validation, logging, error handlers, SceneGraph observers + `m.global` fields |
+| **Dependencies** | Import graph with hot file detection (most imported = highest blast radius); SceneGraph `<script uri="pkg:/...">` and BrighterScript `import` statements |
 | **Contracts** | URL params, request types, response types from route handlers |
-| **Monorepos** | pnpm, npm, yarn workspaces + mixed-language workspaces (e.g. Next.js + Laravel, SwiftUI + Vapor) |
-| **Languages** | TypeScript, JavaScript, Python, Go, Ruby, Elixir, Java, Kotlin, Rust, PHP, Dart, Swift, C# |
+| **Monorepos** | pnpm, npm, yarn workspaces + mixed-language workspaces (e.g. Next.js + Laravel, SwiftUI + Vapor, Roku multi-channel under `src/apps/<creator>/`) |
+| **Languages** | TypeScript, JavaScript, Python, Go, Ruby, Elixir, Java, Kotlin, Rust, PHP, Dart, Swift, C#, BrightScript/BrighterScript |
 
 ## AI Config Generation
 

--- a/src/ast/extract-brighterscript.ts
+++ b/src/ast/extract-brighterscript.ts
@@ -1,0 +1,95 @@
+/**
+ * BrighterScript (.bs) extraction.
+ *
+ * BrighterScript is a superset of BrightScript with added language features:
+ *   - class X extends Y
+ *   - namespace X.Y
+ *   - enum X
+ *   - interface X
+ *   - import "pkg:/source/path/File.brs"
+ *   - try/catch
+ *   - optional chaining (?.)
+ *
+ * This extractor handles only BrighterScript-specific constructs; it composes
+ * with extract-brightscript for functions/subs/observers/etc. so .bs files
+ * get both layers of detection.
+ */
+
+import type { ExportItem } from "../types.js";
+import { extractBrightScriptFunctions } from "./extract-brightscript.js";
+
+/**
+ * Extract import targets from `import "pkg:/..."` statements.
+ * BrighterScript imports must be at the top of a file, but we scan the whole
+ * file for robustness against unusual layouts.
+ */
+export function extractBrighterScriptImports(content: string): string[] {
+  const out: string[] = [];
+  const pattern = /^\s*import\s+["']([^"']+)["']/gim;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(content)) !== null) {
+    out.push(m[1]);
+  }
+  return out;
+}
+
+/**
+ * Extract BrighterScript-only exports (class, namespace, enum, interface)
+ * plus functions/subs via the BrightScript extractor.
+ *
+ * Access modifiers in BrighterScript are not applied to module-level
+ * declarations; every class/namespace/enum/interface is effectively public.
+ */
+export function extractBrighterScriptExports(content: string): ExportItem[] {
+  const exports: ExportItem[] = [];
+  const seen = new Set<string>();
+
+  const push = (name: string, kind: ExportItem["kind"], signature?: string): void => {
+    const key = `${kind}:${name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    exports.push({ name, kind, signature });
+  };
+
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // class X [extends Y]
+    const classMatch = trimmed.match(/^class\s+([A-Za-z_][\w]*)(?:\s+extends\s+([A-Za-z_][\w.]*))?/i);
+    if (classMatch) {
+      const name = classMatch[1];
+      const parent = classMatch[2];
+      push(name, "class", parent ? `class ${name} extends ${parent}` : `class ${name}`);
+      continue;
+    }
+
+    // namespace A.B.C
+    const nsMatch = trimmed.match(/^namespace\s+([A-Za-z_][\w.]*)/i);
+    if (nsMatch) {
+      push(nsMatch[1], "const", `namespace ${nsMatch[1]}`);
+      continue;
+    }
+
+    // enum X
+    const enumMatch = trimmed.match(/^enum\s+([A-Za-z_][\w]*)/i);
+    if (enumMatch) {
+      push(enumMatch[1], "enum", `enum ${enumMatch[1]}`);
+      continue;
+    }
+
+    // interface X
+    const ifaceMatch = trimmed.match(/^interface\s+([A-Za-z_][\w]*)/i);
+    if (ifaceMatch) {
+      push(ifaceMatch[1], "interface", `interface ${ifaceMatch[1]}`);
+      continue;
+    }
+  }
+
+  // Fold in BrightScript function/sub exports too — .bs is a superset.
+  for (const item of extractBrightScriptFunctions(content)) {
+    push(item.name, item.kind, item.signature);
+  }
+
+  return exports;
+}

--- a/src/ast/extract-brightscript.ts
+++ b/src/ast/extract-brightscript.ts
@@ -1,0 +1,255 @@
+/**
+ * BrightScript (.brs) extraction.
+ *
+ * Regex-based — BrightScript has no official AST parser available as a Node
+ * dependency, and real-world .brs code is simple enough for line-oriented
+ * regex to achieve good recall. Matches the convention of extract-swift,
+ * extract-dart, extract-php, etc.
+ *
+ * Exposed helpers:
+ * - extractBrightScriptFunctions: top-level function/sub declarations
+ * - extractBrightScriptObservers: m.top.observeField / m.global.observeField
+ * - extractBrightScriptShowScreenCalls: ShowScreen / CloseScreen / GetCurrentScreen
+ * - extractBrightScriptGraphqlCalls: makeGraphqlCall / roUrlTransfer site hits
+ * - extractBrightScriptGlobalFields: m.global.AddField(...) registrations
+ * - extractBrightScriptRudderstackEvents: event names passed to RudderstackTask
+ */
+
+import type { ExportItem } from "../types.js";
+
+export interface BrightScriptObserver {
+  field: string;
+  handler: string;
+  scope: "top" | "global" | "other";
+  line: number;
+}
+
+export interface ShowScreenCall {
+  target: string;   // variable/expression referenced (e.g. "m.homeView" or "homeView")
+  modal: boolean;   // true when the second positional arg is a literal `true`
+  helper: "show" | "close" | "current";
+  line: number;
+}
+
+export interface GraphqlCallSite {
+  url: string;      // literal text or expression as source
+  /** Line number (1-indexed) of the call-site. */
+  line: number;
+}
+
+export interface GlobalFieldRegistration {
+  name: string;
+  type: string;
+  line: number;
+}
+
+export interface RudderstackEvent {
+  name: string;
+  line: number;
+}
+
+/**
+ * Extract top-level function / sub declarations from .brs source.
+ *
+ * BrightScript syntax is case-insensitive. Declarations we recognize:
+ *   function Foo(a, b as string) as object
+ *   Function Foo()
+ *   sub Bar(x)
+ *   Sub Bar()
+ *
+ * We only match declarations that begin at column 0 to exclude nested
+ * inline function expressions (which BrightScript supports inside tables).
+ */
+export function extractBrightScriptFunctions(content: string): ExportItem[] {
+  const exports: ExportItem[] = [];
+  const lines = content.split("\n");
+  const declPattern = /^(function|sub)\s+([A-Za-z_][\w]*)\s*\(([^)]*)\)/i;
+
+  const seen = new Set<string>();
+  for (const line of lines) {
+    const m = line.match(declPattern);
+    if (!m) continue;
+    const kind = m[1].toLowerCase() === "sub" ? "sub" : "function";
+    const name = m[2];
+    const params = m[3].trim();
+    if (seen.has(name)) continue;
+    seen.add(name);
+    exports.push({
+      name,
+      kind: "function",
+      signature: `${kind} ${name}(${params})`,
+    });
+  }
+
+  return exports;
+}
+
+/**
+ * Extract observeField / observeFieldScoped registrations.
+ *
+ * Patterns recognized:
+ *   m.top.observeField("fieldName", "handlerName")
+ *   m.global.observeField("fieldName", "handlerName")
+ *   someNode.observeField("fieldName", "handlerName")
+ *   m.top.observeFieldScoped("fieldName", "handlerName")
+ */
+export function extractBrightScriptObservers(content: string): BrightScriptObserver[] {
+  const out: BrightScriptObserver[] = [];
+  const lines = content.split("\n");
+  const pattern = /(\bm\.top|\bm\.global|\b[\w.]+?)\.observeField(?:Scoped)?\s*\(\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']/gi;
+
+  for (let i = 0; i < lines.length; i++) {
+    let match: RegExpExecArray | null;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(lines[i])) !== null) {
+      const receiver = match[1];
+      let scope: BrightScriptObserver["scope"] = "other";
+      if (/^m\.top$/i.test(receiver)) scope = "top";
+      else if (/^m\.global$/i.test(receiver)) scope = "global";
+      out.push({ field: match[2], handler: match[3], scope, line: i + 1 });
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract screen-stack navigation call-sites.
+ *
+ * Matches the helpers named in the repo conventions used by this detector:
+ *   ShowScreen(target)
+ *   ShowScreen(target, true)
+ *   CloseScreen()
+ *   GetCurrentScreen()
+ */
+export function extractBrightScriptShowScreenCalls(content: string): ShowScreenCall[] {
+  const out: ShowScreenCall[] = [];
+  const lines = content.split("\n");
+
+  const showPattern = /\bShowScreen\s*\(\s*([^),]+?)\s*(?:,\s*(true|false|\w+))?\s*\)/gi;
+  const closePattern = /\bCloseScreen\s*\(\s*\)/gi;
+  const currentPattern = /\bGetCurrentScreen\s*\(\s*\)/gi;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+
+    showPattern.lastIndex = 0;
+    while ((m = showPattern.exec(line)) !== null) {
+      const target = m[1].trim();
+      const second = (m[2] ?? "").trim().toLowerCase();
+      out.push({
+        target,
+        modal: second === "true",
+        helper: "show",
+        line: i + 1,
+      });
+    }
+
+    closePattern.lastIndex = 0;
+    while ((m = closePattern.exec(line)) !== null) {
+      out.push({ target: "", modal: false, helper: "close", line: i + 1 });
+    }
+
+    currentPattern.lastIndex = 0;
+    while ((m = currentPattern.exec(line)) !== null) {
+      out.push({ target: "", modal: false, helper: "current", line: i + 1 });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Extract GraphQL + raw HTTP call sites.
+ *
+ * makeGraphqlCall(url, payload, params) — used across FrontRow Roku code.
+ * Also catches bare CreateObject("roUrlTransfer").
+ */
+export function extractBrightScriptGraphqlCalls(content: string): GraphqlCallSite[] {
+  const out: GraphqlCallSite[] = [];
+  const lines = content.split("\n");
+  const gqlPattern = /\bmakeGraphqlCall\s*\(\s*([^,]+?)\s*,/gi;
+  const urlXferPattern = /\bCreateObject\s*\(\s*["']roUrlTransfer["']\s*\)/gi;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let m: RegExpExecArray | null;
+    gqlPattern.lastIndex = 0;
+    while ((m = gqlPattern.exec(line)) !== null) {
+      out.push({ url: m[1].trim(), line: i + 1 });
+    }
+    urlXferPattern.lastIndex = 0;
+    while ((m = urlXferPattern.exec(line)) !== null) {
+      out.push({ url: "roUrlTransfer", line: i + 1 });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Extract m.global.AddField("name", "type", ...) registrations.
+ * Used by middleware + config detectors as app-wide declared state.
+ */
+export function extractBrightScriptGlobalFields(content: string): GlobalFieldRegistration[] {
+  const out: GlobalFieldRegistration[] = [];
+  const lines = content.split("\n");
+  const pattern = /\bm\.global\.(?:AddField|addField)\s*\(\s*["']([^"']+)["']\s*,\s*["']([^"']+)["']/gi;
+  for (let i = 0; i < lines.length; i++) {
+    let m: RegExpExecArray | null;
+    pattern.lastIndex = 0;
+    while ((m = pattern.exec(lines[i])) !== null) {
+      out.push({ name: m[1], type: m[2], line: i + 1 });
+    }
+  }
+  return out;
+}
+
+/**
+ * Heuristic: RudderstackTask event name payloads.
+ *
+ * Common shapes in FrontRow code:
+ *   rudderstackTask.event = { event: "EventName", properties: {...} }
+ *   rudderstackTask.callFunc("trackEvent", "EventName", {...})
+ */
+export function extractBrightScriptRudderstackEvents(content: string): RudderstackEvent[] {
+  const out: RudderstackEvent[] = [];
+  const lines = content.split("\n");
+  const eventFieldPattern = /\bevent\s*:\s*["']([^"']+)["']/gi;
+  const callFuncPattern = /rudderstack[\w.]*\.callFunc\s*\(\s*["'][^"']*["']\s*,\s*["']([^"']+)["']/gi;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Only treat `event: "..."` as a rudderstack event when rudderstack is named
+    // nearby; this avoids false-positives on generic code.
+    if (/rudderstack/i.test(line) || /\btrackEvent\b/i.test(line)) {
+      let m: RegExpExecArray | null;
+      eventFieldPattern.lastIndex = 0;
+      while ((m = eventFieldPattern.exec(line)) !== null) {
+        out.push({ name: m[1], line: i + 1 });
+      }
+    }
+    let m: RegExpExecArray | null;
+    callFuncPattern.lastIndex = 0;
+    while ((m = callFuncPattern.exec(line)) !== null) {
+      out.push({ name: m[1], line: i + 1 });
+    }
+  }
+  return out;
+}
+
+/**
+ * Find `m.xxxView = m.top.findNode("xxxView")` style bindings.
+ * Used by routes detector to resolve `ShowScreen(m.xxxView)` back to a node id.
+ */
+export function extractFindNodeBindings(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const lines = content.split("\n");
+  const pattern = /\bm\.(\w+)\s*=\s*m\.top\.findNode\s*\(\s*["']([^"']+)["']\s*\)/i;
+  for (const line of lines) {
+    const m = line.match(pattern);
+    if (!m) continue;
+    result[`m.${m[1]}`] = m[2];
+  }
+  return result;
+}

--- a/src/ast/extract-brightscript.ts
+++ b/src/ast/extract-brightscript.ts
@@ -113,13 +113,59 @@ export function extractBrightScriptObservers(content: string): BrightScriptObser
 }
 
 /**
+ * Extract screen-open call-sites for a configurable set of helper names.
+ *
+ * Roku apps don't have a standard navigation helper — some use `ShowScreen`,
+ * others `pushScreen`, `NavigateTo`, `showView`, or project-specific names.
+ * This generalized form scans for any `<helperName>(target, [modal?])`
+ * call site where the target is a node variable or bare identifier.
+ *
+ * Returns one entry per call-site. `modal` is true when the second positional
+ * argument is the literal `true` (Roku BrightScript has no named args).
+ */
+export function extractBrightScriptNavigationCalls(
+  content: string,
+  helperNames: string[]
+): ShowScreenCall[] {
+  const out: ShowScreenCall[] = [];
+  if (helperNames.length === 0) return out;
+  const lines = content.split("\n");
+  const alternation = helperNames.map((h) => h.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const pattern = new RegExp(
+    `\\b(?:${alternation})\\s*\\(\\s*([^),]+?)\\s*(?:,\\s*(true|false|\\w+))?\\s*\\)`,
+    "gi"
+  );
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    pattern.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(line)) !== null) {
+      const target = m[1].trim();
+      // Skip obvious non-targets (empty string literal, string literal, number)
+      if (!target || /^["']/.test(target) || /^\d/.test(target)) continue;
+      const second = (m[2] ?? "").trim().toLowerCase();
+      out.push({
+        target,
+        modal: second === "true",
+        helper: "show",
+        line: i + 1,
+      });
+    }
+  }
+  return out;
+}
+
+/**
  * Extract screen-stack navigation call-sites.
  *
- * Matches the helpers named in the repo conventions used by this detector:
+ * Matches the FrontRow-style helpers:
  *   ShowScreen(target)
  *   ShowScreen(target, true)
  *   CloseScreen()
  *   GetCurrentScreen()
+ *
+ * Retained for back-compat; new code should prefer
+ * `extractBrightScriptNavigationCalls` which takes a configurable name set.
  */
 export function extractBrightScriptShowScreenCalls(content: string): ShowScreenCall[] {
   const out: ShowScreenCall[] = [];

--- a/src/ast/extract-scenegraph.ts
+++ b/src/ast/extract-scenegraph.ts
@@ -1,0 +1,182 @@
+/**
+ * Roku SceneGraph XML extraction.
+ *
+ * SceneGraph components are XML files that declare:
+ * - a component name + parent type  (`<component name="X" extends="Group">`)
+ * - public fields/functions (`<interface> <field ... /> </interface>`)
+ * - script includes             (`<script uri="pkg:/..." />`)
+ * - nested child components     (`<children> <Label .../> </children>`)
+ *
+ * This file exposes two regex-based extractors — no XML parser dependency,
+ * matching the style of every other extractor in src/ast/.
+ */
+
+import type { SchemaField } from "../types.js";
+
+export interface SceneGraphComponent {
+  /** Value of the `name=` attribute on the top-level <component>. */
+  name: string;
+  /** Value of the `extends=` attribute, or "Group" as a conservative default. */
+  extendsType: string;
+  /** Fields declared under <interface> — drives schema + components detectors. */
+  interfaceFields: SchemaField[];
+  /** Functions declared under <interface> — drives libs detector for XML side. */
+  interfaceFunctions: string[];
+  /** Script include targets from <script uri="pkg:/..." />. */
+  scriptIncludes: string[];
+  /** Direct child component type names declared under <children>. */
+  childComponents: string[];
+}
+
+/**
+ * Parse a single SceneGraph component XML file.
+ *
+ * Returns null for XML that is not a SceneGraph component (Android layouts,
+ * Spring configs, raw XML data, etc.). The signature is a top-level
+ * `<component name="..." extends="...">` element.
+ */
+export function extractSceneGraphComponent(content: string): SceneGraphComponent | null {
+  const componentMatch = content.match(/<component\s+([^>]+?)\s*(?:>|\/>)/i);
+  if (!componentMatch) return null;
+
+  const attrs = componentMatch[1];
+  const name = attrs.match(/\bname\s*=\s*["']([^"']+)["']/i)?.[1];
+  if (!name) return null;
+  const extendsType = attrs.match(/\bextends\s*=\s*["']([^"']+)["']/i)?.[1] ?? "Group";
+
+  const interfaceFields: SchemaField[] = [];
+  const interfaceFunctions: string[] = [];
+  const interfaceBlock = content.match(/<interface\b[^>]*>([\s\S]*?)<\/interface>/i);
+  if (interfaceBlock) {
+    const body = interfaceBlock[1];
+
+    const fieldPattern = /<field\s+([^>]+?)\s*\/?\s*>/gi;
+    let m: RegExpExecArray | null;
+    while ((m = fieldPattern.exec(body)) !== null) {
+      const fieldAttrs = m[1];
+      const id = fieldAttrs.match(/\bid\s*=\s*["']([^"']+)["']/i)?.[1];
+      if (!id) continue;
+      const rawType = fieldAttrs.match(/\btype\s*=\s*["']([^"']+)["']/i)?.[1] ?? "unknown";
+      const hasDefault = /\bvalue\s*=/i.test(fieldAttrs) || /\bdefault\s*=/i.test(fieldAttrs);
+      const isAlias = /\balias\s*=/i.test(fieldAttrs);
+      const flags: string[] = [];
+      if (hasDefault) flags.push("default");
+      if (isAlias) flags.push("alias");
+      interfaceFields.push({ name: id, type: normalizeSceneGraphType(rawType), flags });
+    }
+
+    const functionPattern = /<function\s+([^>]+?)\s*\/?\s*>/gi;
+    while ((m = functionPattern.exec(body)) !== null) {
+      const fnName = m[1].match(/\bname\s*=\s*["']([^"']+)["']/i)?.[1];
+      if (fnName) interfaceFunctions.push(fnName);
+    }
+  }
+
+  const scriptIncludes: string[] = [];
+  const scriptPattern = /<script\s+([^>]+?)\s*\/?\s*>/gi;
+  let s: RegExpExecArray | null;
+  while ((s = scriptPattern.exec(content)) !== null) {
+    const uri = s[1].match(/\buri\s*=\s*["']([^"']+)["']/i)?.[1];
+    if (uri) scriptIncludes.push(uri);
+  }
+
+  const childComponents: string[] = [];
+  const childrenBlock = content.match(/<children\b[^>]*>([\s\S]*?)<\/children>/i);
+  if (childrenBlock) {
+    const body = childrenBlock[1];
+    // Match any element open tag — component types are uppercase-initial by convention
+    const childPattern = /<([A-Z][\w:-]*)\b/g;
+    let c: RegExpExecArray | null;
+    while ((c = childPattern.exec(body)) !== null) {
+      childComponents.push(c[1]);
+    }
+  }
+
+  return { name, extendsType, interfaceFields, interfaceFunctions, scriptIncludes, childComponents };
+}
+
+/**
+ * For a MainScene xml, return the map of `{ id -> componentType }` describing
+ * every child view slot. Values of `m.top.findNode("xxx")` in MainScene.brs
+ * resolve back to these IDs.
+ *
+ * Roku Scene XML typically looks like:
+ *   <component name="MainScene" extends="Scene">
+ *     <children>
+ *       <HomeView id="homeView" />
+ *       <LoginView id="loginView" />
+ *     </children>
+ *   </component>
+ */
+export function extractMainSceneScreens(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const childrenBlock = content.match(/<children\b[^>]*>([\s\S]*?)<\/children>/i);
+  if (!childrenBlock) return result;
+
+  const body = childrenBlock[1];
+  // Each child element: <ComponentType id="slotId" ... />
+  const elementPattern = /<([A-Z][\w:-]*)\b([^>]*)\/?>/g;
+  let m: RegExpExecArray | null;
+  while ((m = elementPattern.exec(body)) !== null) {
+    const componentType = m[1];
+    const attrs = m[2];
+    const id = attrs.match(/\bid\s*=\s*["']([^"']+)["']/i)?.[1];
+    if (!id) continue;
+    result[id] = componentType;
+  }
+  return result;
+}
+
+/**
+ * Cheap content sniff: is this XML file a SceneGraph component?
+ * Used by detectors to filter the broad `.xml` file set down to SceneGraph XML.
+ */
+export function isSceneGraphXml(content: string): boolean {
+  if (!/<component\b/i.test(content)) return false;
+  if (!/\bname\s*=/i.test(content)) return false;
+  // Android layouts start with <?xml then a specific Android namespace or a
+  // layout root (LinearLayout, ConstraintLayout, etc.). They don't have
+  // <component>, so the check above already excludes them. Spring configs
+  // use <beans>. Belt-and-braces: reject obvious Android namespaces.
+  if (/xmlns:android\s*=/.test(content)) return false;
+  return true;
+}
+
+function normalizeSceneGraphType(raw: string): string {
+  const t = raw.trim().toLowerCase();
+  switch (t) {
+    case "string":
+    case "str":
+      return "string";
+    case "integer":
+    case "int":
+      return "int";
+    case "float":
+      return "float";
+    case "boolean":
+    case "bool":
+      return "bool";
+    case "double":
+      return "double";
+    case "longinteger":
+      return "longInteger";
+    case "node":
+      return "node-ref";
+    case "nodearray":
+      return "node-ref[]";
+    case "array":
+      return "array";
+    case "assocarray":
+      return "object";
+    case "color":
+      return "color";
+    case "vector2d":
+      return "vector2d";
+    case "rect2d":
+      return "rect2d";
+    case "time":
+      return "time";
+    default:
+      return raw;
+  }
+}

--- a/src/detectors/components.ts
+++ b/src/detectors/components.ts
@@ -89,6 +89,8 @@ export async function detectComponents(
       return detectComposeComponentsFromFiles(files, project);
     case "angular":
       return detectAngularComponents(files, project);
+    case "scenegraph":
+      return detectSceneGraphComponents(files, project);
     default: {
       // SwiftUI: no componentFramework flag — detect if swiftui/vapor framework present
       if (
@@ -480,6 +482,43 @@ async function detectSwiftUIComponents(
     if (!content.includes(": View") && !content.includes(":View")) continue;
     const rel = relative(project.root, file);
     components.push(...extractSwiftUIViews(rel, content));
+  }
+
+  return components;
+}
+
+// --- SceneGraph (Roku) ---
+//
+// Every `.xml` file whose root is a `<component name="..." extends="...">`
+// element is a SceneGraph component. Props = `<field>` ids declared under
+// `<interface>`. The paired `.brs`/`.bs` lives alongside; we don't need to
+// read it for component metadata.
+async function detectSceneGraphComponents(
+  files: string[],
+  project: ProjectInfo
+): Promise<ComponentInfo[]> {
+  const { extractSceneGraphComponent, isSceneGraphXml } = await import("../ast/extract-scenegraph.js");
+  const xmlFiles = files.filter((f) => f.endsWith(".xml"));
+  const components: ComponentInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const file of xmlFiles) {
+    const content = await readFileSafe(file);
+    if (!content || !isSceneGraphXml(content)) continue;
+    const comp = extractSceneGraphComponent(content);
+    if (!comp) continue;
+    if (seen.has(comp.name)) continue;
+    seen.add(comp.name);
+
+    const rel = relative(project.root, file).replace(/\\/g, "/");
+    components.push({
+      name: comp.name,
+      file: rel,
+      confidence: "regex",
+      props: comp.interfaceFields.map((f) => f.name),
+      isClient: true,
+      isServer: false,
+    });
   }
 
   return components;

--- a/src/detectors/config.ts
+++ b/src/detectors/config.ts
@@ -48,6 +48,22 @@ export async function detectConfig(
     }
   }
 
+  // Roku channel `manifest` files are plain-text key/value configs — surface
+  // them in configFiles. Covers both root-level and per-creator channels.
+  if (project.frameworks.includes("roku-scenegraph")) {
+    const manifestHits = files.filter((f) => basename(f) === "manifest");
+    for (const m of manifestHits) {
+      const rel = relative(project.root, m);
+      if (!configFiles.includes(rel)) configFiles.push(rel);
+    }
+    // Root-level manifest may not be in `files` (no extension filter) — check
+    // directly for Roku monorepos whose channels live at nested paths.
+    const rootManifest = await readFileSafe(join(project.root, "manifest"));
+    if (rootManifest && /^\s*title\s*=/m.test(rootManifest) && !configFiles.includes("manifest")) {
+      configFiles.push("manifest");
+    }
+  }
+
   // Detect env vars
   const envVars = await detectEnvVars(files, project);
 
@@ -165,6 +181,57 @@ async function detectEnvVars(
       const name = match[1];
       if (!envMap.has(name)) {
         envMap.set(name, { name, source: rel, hasDefault: false });
+      }
+    }
+  }
+
+  // ─── Roku config sources ────────────────────────────────────────────────
+  //
+  // Roku apps don't use .env files — their runtime configuration lives in:
+  //   1. `manifest` (key=value, one entry per line) at the channel root
+  //   2. `appConfig.brs` (initConfig / initAppConfig functions returning an
+  //      associative array of constants)
+  // Both are surfaced as EnvVars so the AI context map highlights them.
+  if (project.frameworks.includes("roku-scenegraph")) {
+    const manifestFiles = files.filter((f) => basename(f) === "manifest");
+    // Fallback: check the root manifest directly too.
+    const rootManifestPath = join(project.root, "manifest");
+    try {
+      const rootManifest = await readFileSafe(rootManifestPath);
+      if (rootManifest && /^\s*title\s*=/m.test(rootManifest)) {
+        manifestFiles.push(rootManifestPath);
+      }
+    } catch {}
+
+    for (const mfile of manifestFiles) {
+      const content = await readFileSafe(mfile);
+      if (!content) continue;
+      const source = relative(project.root, mfile) || "manifest";
+      for (const line of content.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+        const m = trimmed.match(/^([A-Za-z_][\w]*)\s*=\s*(.*)$/);
+        if (!m) continue;
+        const name = `manifest.${m[1]}`;
+        const hasDefault = m[2].trim().length > 0;
+        if (!envMap.has(name)) envMap.set(name, { name, source, hasDefault });
+      }
+    }
+
+    // appConfig.brs: recognise `CONSTANT_NAME: "value"` or `name = "value"` in
+    // init*Config functions. Only capture keys that look like config constants
+    // (UPPER_SNAKE_CASE) to avoid noisy captures of local variables.
+    const appConfigFiles = files.filter((f) => /appConfig\.brs$/i.test(f));
+    const constPattern = /\b([A-Z][A-Z0-9_]{2,})\s*[:=]\s*["']([^"']*)["']/g;
+    for (const file of appConfigFiles) {
+      const content = await readFileSafe(file);
+      if (!content) continue;
+      const source = relative(project.root, file).replace(/\\/g, "/");
+      let m: RegExpExecArray | null;
+      while ((m = constPattern.exec(content)) !== null) {
+        const name = m[1];
+        if (envMap.has(name)) continue;
+        envMap.set(name, { name, source, hasDefault: m[2].length > 0 });
       }
     }
   }

--- a/src/detectors/events.ts
+++ b/src/detectors/events.ts
@@ -15,7 +15,7 @@ export async function detectEvents(
   const events: EventInfo[] = [];
 
   const relevantFiles = files.filter(
-    (f) => /\.(ts|tsx|js|jsx|mjs|py|rb|ex|exs)$/.test(f) && !f.includes("node_modules")
+    (f) => /\.(ts|tsx|js|jsx|mjs|py|rb|ex|exs|brs|bs)$/.test(f) && !f.includes("node_modules")
   );
 
   for (const file of relevantFiles) {
@@ -112,6 +112,33 @@ export async function detectEvents(
           name: m[1],
           type: "channel",
           system: "redis-pub-sub",
+          file: rel,
+        });
+      }
+    }
+
+    // Roku SceneGraph: observeField subscriptions + RudderstackTask events.
+    // Every observed field is a reactive-style event bus inside the scene
+    // graph; Rudderstack events are the analytics topic stream for the app.
+    if (file.endsWith(".brs") || file.endsWith(".bs")) {
+      const { extractBrightScriptObservers, extractBrightScriptRudderstackEvents } =
+        await import("../ast/extract-brightscript.js");
+
+      for (const obs of extractBrightScriptObservers(content)) {
+        events.push({
+          name: obs.field,
+          type: "event",
+          system: "scenegraph-observer",
+          file: rel,
+          payloadType: obs.scope === "global" ? "m.global" : "node-field",
+        });
+      }
+
+      for (const evt of extractBrightScriptRudderstackEvents(content)) {
+        events.push({
+          name: evt.name,
+          type: "topic",
+          system: "rudderstack",
           file: rel,
         });
       }

--- a/src/detectors/graph.ts
+++ b/src/detectors/graph.ts
@@ -10,7 +10,7 @@ export async function detectDependencyGraph(
   const importCount = new Map<string, number>();
 
   const codeFiles = files.filter((f) =>
-    f.match(/\.(ts|tsx|js|jsx|mjs|py|go|rb|ex|exs|java|kt|rs|php)$/)
+    f.match(/\.(ts|tsx|js|jsx|mjs|py|go|rb|ex|exs|java|kt|rs|php|brs|bs|xml)$/)
   );
 
   // Build a lookup map for faster resolution: relative path -> true
@@ -41,6 +41,14 @@ export async function detectDependencyGraph(
       extractJavaImports(content, rel, edges, importCount, relPaths);
     } else if (ext === ".rs") {
       extractRustImports(content, rel, edges, importCount);
+    } else if (ext === ".brs") {
+      // BrightScript has no top-level imports; dependency edges come from the
+      // paired XML via <script uri="pkg:/..." />. Skip here — XML branch picks
+      // up the inbound edges for this file.
+    } else if (ext === ".bs") {
+      extractBrighterScriptImportsInline(content, rel, edges, importCount, relPathSet);
+    } else if (ext === ".xml") {
+      extractSceneGraphImportsInline(content, rel, edges, importCount, relPathSet);
     } else {
       extractTSImports(content, rel, file, project, relPathSet, edges, importCount);
     }
@@ -234,5 +242,74 @@ function normalizeImportPath(
     if (relPathSet.has(importPath + "/index" + ext)) return importPath + "/index" + ext;
   }
 
+  return null;
+}
+
+// ─── Roku SceneGraph imports ──────────────────────────────────────────────────
+//
+// Roku dependency edges come from two places:
+//   - <script uri="pkg:/source/utils/Utils.brs" /> in component XML
+//   - `import "pkg:/source/utils/Utils.brs"` in BrighterScript (.bs) files
+// Both forms use the `pkg:/` protocol. The root depends on the channel layout;
+// common conventions put BRS files directly under the channel root or under
+// a creator dir (src/apps/<creator>/). We normalize by stripping `pkg:/` and
+// matching against any file whose relative path ends with the import target.
+
+function extractSceneGraphImportsInline(
+  content: string,
+  rel: string,
+  edges: ImportEdge[],
+  importCount: Map<string, number>,
+  relPathSet: Set<string>
+): void {
+  // Only SceneGraph XML declares script includes — bail early on non-SceneGraph XML
+  if (!/<component\b/i.test(content) && !/<script\b/i.test(content)) return;
+  const pattern = /<script\s+[^>]*\buri\s*=\s*["']([^"']+)["']/gi;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(content)) !== null) {
+    const target = resolveRokuImport(m[1], relPathSet);
+    if (target && target !== rel) {
+      edges.push({ from: rel, to: target });
+      importCount.set(target, (importCount.get(target) || 0) + 1);
+    }
+  }
+}
+
+function extractBrighterScriptImportsInline(
+  content: string,
+  rel: string,
+  edges: ImportEdge[],
+  importCount: Map<string, number>,
+  relPathSet: Set<string>
+): void {
+  const pattern = /^\s*import\s+["']([^"']+)["']/gim;
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(content)) !== null) {
+    const target = resolveRokuImport(m[1], relPathSet);
+    if (target && target !== rel) {
+      edges.push({ from: rel, to: target });
+      importCount.set(target, (importCount.get(target) || 0) + 1);
+    }
+  }
+}
+
+/**
+ * Roku packaging flattens files under a channel root, then exposes them via
+ * `pkg:/...` URIs. The same file might live at `src/apps/foo/source/Bar.brs`
+ * in the repo. Strip the protocol and match against any known rel path that
+ * ends with the target suffix.
+ */
+function resolveRokuImport(uri: string, relPathSet: Set<string>): string | null {
+  const stripped = uri.replace(/^pkg:\/+/, "").replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!stripped) return null;
+  // Exact match first (flat layout)
+  if (relPathSet.has(stripped)) return stripped;
+  // Suffix match — handles nested channel layouts like src/apps/<creator>/
+  for (const candidate of relPathSet) {
+    const normalized = candidate.replace(/\\/g, "/");
+    if (normalized.endsWith("/" + stripped) || normalized === stripped) {
+      return candidate;
+    }
+  }
   return null;
 }

--- a/src/detectors/libs.ts
+++ b/src/detectors/libs.ts
@@ -4,6 +4,8 @@ import { extractDartExports } from "../ast/extract-dart.js";
 import { extractSwiftExports } from "../ast/extract-swift.js";
 import { extractCSharpExports } from "../ast/extract-csharp.js";
 import { extractPhpExports } from "../ast/extract-php.js";
+import { extractBrightScriptFunctions } from "../ast/extract-brightscript.js";
+import { extractBrighterScriptExports } from "../ast/extract-brighterscript.js";
 import type { LibExport, ExportItem, ProjectInfo } from "../types.js";
 
 const SKIP_DIRS = [
@@ -26,16 +28,25 @@ export async function detectLibs(
 ): Promise<LibExport[]> {
   const libFiles = files.filter((f) => {
     const ext = extname(f);
-    if (![".ts", ".js", ".mjs", ".py", ".go", ".dart", ".swift", ".cs", ".php"].includes(ext)) return false;
+    if (![".ts", ".js", ".mjs", ".py", ".go", ".dart", ".swift", ".cs", ".php", ".brs", ".bs"].includes(ext)) return false;
     if (f.endsWith(".test.ts") || f.endsWith(".spec.ts")) return false;
     if (f.endsWith(".test.js") || f.endsWith(".spec.js")) return false;
     if (f.endsWith(".d.ts")) return false;
     if (f.endsWith("_test.py") || f.endsWith("_test.go")) return false;
     if (f.endsWith("_test.dart") || f.endsWith(".g.dart")) return false;
     if (f.endsWith("Tests.swift") || f.endsWith("_test.swift")) return false;
+    // Check dir-based skips on the project-relative path, not the absolute
+    // one — otherwise a project that happens to live under a parent `tests/`
+    // dir (e.g. test fixtures) has all its lib files silently dropped.
+    const relForFilter = "/" + relative(project.root, f).replace(/\\/g, "/");
+    // Roku: skip test suites + component BRS (components/ already holds view logic)
+    if (ext === ".brs" || ext === ".bs") {
+      if (/\/tests?\//i.test(relForFilter)) return false;
+      if (/\/components\//i.test(relForFilter)) return false;
+    }
     // Skip component/page/route files
     if (f.endsWith(".tsx") || f.endsWith(".jsx")) return false;
-    if (SKIP_DIRS.some((d) => f.includes(d))) return false;
+    if (SKIP_DIRS.some((d) => relForFilter.includes(d))) return false;
     return true;
   });
 
@@ -61,6 +72,10 @@ export async function detectLibs(
       exports = extractCSharpExports(content);
     } else if (ext === ".php") {
       exports = extractPhpExports(content);
+    } else if (ext === ".brs") {
+      exports = extractBrightScriptFunctions(content);
+    } else if (ext === ".bs") {
+      exports = extractBrighterScriptExports(content);
     } else {
       exports = extractTSExports(content);
     }

--- a/src/detectors/middleware.ts
+++ b/src/detectors/middleware.ts
@@ -164,5 +164,54 @@ export async function detectMiddleware(
     }
   }
 
+  // ─── Roku SceneGraph middleware ─────────────────────────────────────────
+  //
+  // SceneGraph doesn't have HTTP-style middleware, but the closest analog is:
+  //   - cross-component observers: `m.top.observeField("x", handler)` and
+  //     `m.global.AddField(...)` set up app-wide reactive bindings.
+  //   - Bugsnag + Rudderstack telemetry tasks are wired at scene boot, acting
+  //     as logging/error-handler middleware for the whole app.
+  if (project.frameworks.includes("roku-scenegraph")) {
+    const { extractBrightScriptObservers, extractBrightScriptGlobalFields } =
+      await import("../ast/extract-brightscript.js");
+    const brsFiles = files.filter((f) => f.endsWith(".brs") || f.endsWith(".bs"));
+
+    for (const file of brsFiles) {
+      const content = await readFileSafe(file);
+      if (!content) continue;
+      const rel = relative(project.root, file).replace(/\\/g, "/");
+
+      for (const obs of extractBrightScriptObservers(content)) {
+        const name = `observeField(${obs.field}) -> ${obs.handler}`;
+        if (middleware.some((m) => m.name === name && m.file === rel)) continue;
+        middleware.push({
+          name,
+          file: rel,
+          type: obs.scope === "global" ? "custom" : "custom",
+        });
+      }
+
+      for (const gf of extractBrightScriptGlobalFields(content)) {
+        const name = `m.global.${gf.name}: ${gf.type}`;
+        if (middleware.some((m) => m.name === name)) continue;
+        middleware.push({ name, file: rel, type: "custom" });
+      }
+
+      // Bugsnag + Rudderstack are logging-layer middleware in Roku apps
+      if (/bugsnag/i.test(content) && /\bBugsnagTask\b/.test(content)) {
+        const name = "BugsnagTask";
+        if (!middleware.some((m) => m.name === name)) {
+          middleware.push({ name, file: rel, type: "error-handler" });
+        }
+      }
+      if (/RudderstackTask/.test(content)) {
+        const name = "RudderstackTask";
+        if (!middleware.some((m) => m.name === name)) {
+          middleware.push({ name, file: rel, type: "logging" });
+        }
+      }
+    }
+  }
+
   return middleware;
 }

--- a/src/detectors/routes.ts
+++ b/src/detectors/routes.ts
@@ -138,6 +138,9 @@ export async function detectRoutes(
       case "angular":
         routes.push(...(await detectAngularRoutes(files, project)));
         break;
+      case "roku-scenegraph":
+        routes.push(...(await detectRokuScreens(files, project)));
+        break;
     }
   }
 
@@ -1585,6 +1588,105 @@ async function detectAngularRoutes(
         framework: "angular",
         confidence: "regex",
       });
+    }
+  }
+
+  return routes;
+}
+
+// ─── Roku SceneGraph: screen navigation ───────────────────────────────────────
+//
+// Roku apps are client-side, so "routes" map to screens the user can navigate
+// to rather than HTTP endpoints. We key off MainScene.xml + MainScene.brs:
+//   - MainScene.xml declares `<children><HomeView id="homeView"/></children>`
+//   - MainScene.brs does `m.homeView = m.top.findNode("homeView")`
+//   - Then `ShowScreen(m.homeView, true)` opens it (modal when 2nd arg true).
+//
+// Each ShowScreen call-site becomes one RouteInfo with method="VIEW" or
+// "MODAL", path="/<id>", and file pointing at the XML that implements the
+// screen. We also fall back to any Scene-extending XML (a multi-scene app).
+
+async function detectRokuScreens(
+  files: string[],
+  project: ProjectInfo
+): Promise<RouteInfo[]> {
+  const { extractSceneGraphComponent, extractMainSceneScreens, isSceneGraphXml } =
+    await import("../ast/extract-scenegraph.js");
+  const { extractBrightScriptShowScreenCalls, extractFindNodeBindings } =
+    await import("../ast/extract-brightscript.js");
+
+  const xmlFiles = files.filter((f) => f.endsWith(".xml"));
+  const brsFiles = files.filter((f) => f.endsWith(".brs") || f.endsWith(".bs"));
+
+  // Build a map of SceneGraph component name -> relative XML file path.
+  // Used to resolve child ids (e.g. "homeView" slot) to the XML that
+  // implements the view (e.g. `views/HomeView.xml`).
+  const componentToFile = new Map<string, string>();
+  const sceneXmls: { file: string; content: string; name: string }[] = [];
+
+  for (const file of xmlFiles) {
+    const content = await readFileSafe(file);
+    if (!content || !isSceneGraphXml(content)) continue;
+    const comp = extractSceneGraphComponent(content);
+    if (!comp) continue;
+    const rel = relative(project.root, file).replace(/\\/g, "/");
+    componentToFile.set(comp.name, rel);
+    if (comp.extendsType.toLowerCase() === "scene" || comp.name.toLowerCase().endsWith("scene")) {
+      sceneXmls.push({ file: rel, content, name: comp.name });
+    }
+  }
+
+  const routes: RouteInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const scene of sceneXmls) {
+    const slotToType = extractMainSceneScreens(scene.content);
+
+    // Find the paired .brs/.bs — same directory + same stem.
+    const stem = scene.file.replace(/\.xml$/i, "");
+    const pairedBrs = brsFiles.find((f) => {
+      const rel = relative(project.root, f).replace(/\\/g, "/").replace(/\.(brs|bs)$/i, "");
+      return rel === stem;
+    });
+
+    // ShowScreen / CloseScreen / GetCurrentScreen call-sites across the scene
+    // BRS plus any other BRS that references the scene's slots. Most apps
+    // invoke these from the scene itself, but helpers in source/ can too.
+    const brsSources: { file: string; content: string }[] = [];
+    if (pairedBrs) {
+      const pc = await readFileSafe(pairedBrs);
+      if (pc) brsSources.push({ file: pairedBrs, content: pc });
+    }
+
+    // Build slot-variable lookup from the paired BRS:
+    //   m.homeView = m.top.findNode("homeView")  => { "m.homeView": "homeView" }
+    const varToSlot: Record<string, string> = {};
+    for (const src of brsSources) {
+      Object.assign(varToSlot, extractFindNodeBindings(src.content));
+    }
+
+    for (const src of brsSources) {
+      const calls = extractBrightScriptShowScreenCalls(src.content);
+      const tags = detectTags(src.content);
+      for (const call of calls) {
+        if (call.helper !== "show") continue;
+        const slot = varToSlot[call.target] ?? call.target.replace(/^m\./, "");
+        const componentType = slotToType[slot];
+        const routeFile = componentType ? (componentToFile.get(componentType) ?? scene.file) : scene.file;
+        const method = call.modal ? "MODAL" : "VIEW";
+        const path = `/${slot}`;
+        const key = `${method}:${path}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        routes.push({
+          method,
+          path,
+          file: routeFile,
+          tags,
+          framework: "roku-scenegraph",
+          confidence: "regex",
+        });
+      }
     }
   }
 

--- a/src/detectors/routes.ts
+++ b/src/detectors/routes.ts
@@ -139,7 +139,7 @@ export async function detectRoutes(
         routes.push(...(await detectAngularRoutes(files, project)));
         break;
       case "roku-scenegraph":
-        routes.push(...(await detectRokuScreens(files, project)));
+        routes.push(...(await detectRokuScreens(files, project, config)));
         break;
     }
   }
@@ -1596,31 +1596,54 @@ async function detectAngularRoutes(
 
 // ─── Roku SceneGraph: screen navigation ───────────────────────────────────────
 //
-// Roku apps are client-side, so "routes" map to screens the user can navigate
-// to rather than HTTP endpoints. We key off MainScene.xml + MainScene.brs:
-//   - MainScene.xml declares `<children><HomeView id="homeView"/></children>`
-//   - MainScene.brs does `m.homeView = m.top.findNode("homeView")`
-//   - Then `ShowScreen(m.homeView, true)` opens it (modal when 2nd arg true).
+// Roku apps are client-side; "routes" map to screens the user can navigate
+// to. The one convention every SceneGraph app shares is that a Scene XML
+// declares its view slots in `<children>`:
 //
-// Each ShowScreen call-site becomes one RouteInfo with method="VIEW" or
-// "MODAL", path="/<id>", and file pointing at the XML that implements the
-// screen. We also fall back to any Scene-extending XML (a multi-scene app).
+//   <component name="MainScene" extends="Scene">
+//     <children>
+//       <HomeView id="homeView" />
+//       <LoginView id="loginView" />
+//     </children>
+//   </component>
+//
+// Each child with an `id` attribute is one screen, regardless of how the app
+// navigates to it (toggle visible, custom helper, Kopytko router, etc.).
+//
+// We then OPTIONALLY enrich routes by scanning paired BRS for helper calls
+// like `ShowScreen(m.homeView, true)`. When found with a literal `true`
+// second argument, the matching route is flipped from VIEW to MODAL. Helper
+// names are configurable via `CodesightConfig.rokuScreenHelpers` with a
+// sensible default set that covers the common conventions.
+
+const DEFAULT_ROKU_SCREEN_HELPERS = [
+  "ShowScreen",
+  "showScreen",
+  "pushScreen",
+  "PushScreen",
+  "NavigateTo",
+  "navigateTo",
+  "showView",
+  "ShowView",
+];
 
 async function detectRokuScreens(
   files: string[],
-  project: ProjectInfo
+  project: ProjectInfo,
+  config?: CodesightConfig
 ): Promise<RouteInfo[]> {
   const { extractSceneGraphComponent, extractMainSceneScreens, isSceneGraphXml } =
     await import("../ast/extract-scenegraph.js");
-  const { extractBrightScriptShowScreenCalls, extractFindNodeBindings } =
+  const { extractBrightScriptNavigationCalls, extractFindNodeBindings } =
     await import("../ast/extract-brightscript.js");
 
   const xmlFiles = files.filter((f) => f.endsWith(".xml"));
   const brsFiles = files.filter((f) => f.endsWith(".brs") || f.endsWith(".bs"));
+  const helperNames = config?.rokuScreenHelpers ?? DEFAULT_ROKU_SCREEN_HELPERS;
 
-  // Build a map of SceneGraph component name -> relative XML file path.
-  // Used to resolve child ids (e.g. "homeView" slot) to the XML that
-  // implements the view (e.g. `views/HomeView.xml`).
+  // Build a map of SceneGraph component name -> relative XML file path so
+  // view slots (e.g. `<HomeView id="homeView"/>`) resolve to the XML that
+  // implements the view (e.g. `components/views/HomeView.xml`).
   const componentToFile = new Map<string, string>();
   const sceneXmls: { file: string; content: string; name: string }[] = [];
 
@@ -1637,10 +1660,28 @@ async function detectRokuScreens(
   }
 
   const routes: RouteInfo[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, RouteInfo>(); // key: path — lets us upgrade VIEW -> MODAL later
 
   for (const scene of sceneXmls) {
     const slotToType = extractMainSceneScreens(scene.content);
+
+    // Primary: every child id becomes a screen, regardless of how the app
+    // opens it. This is the robust, universal signal.
+    for (const [slot, componentType] of Object.entries(slotToType)) {
+      const routeFile = componentToFile.get(componentType) ?? scene.file;
+      const path = `/${slot}`;
+      if (seen.has(path)) continue;
+      const route: RouteInfo = {
+        method: "VIEW",
+        path,
+        file: routeFile,
+        tags: [],
+        framework: "roku-scenegraph",
+        confidence: "regex",
+      };
+      seen.set(path, route);
+      routes.push(route);
+    }
 
     // Find the paired .brs/.bs — same directory + same stem.
     const stem = scene.file.replace(/\.xml$/i, "");
@@ -1649,43 +1690,55 @@ async function detectRokuScreens(
       return rel === stem;
     });
 
-    // ShowScreen / CloseScreen / GetCurrentScreen call-sites across the scene
-    // BRS plus any other BRS that references the scene's slots. Most apps
-    // invoke these from the scene itself, but helpers in source/ can too.
     const brsSources: { file: string; content: string }[] = [];
     if (pairedBrs) {
       const pc = await readFileSafe(pairedBrs);
       if (pc) brsSources.push({ file: pairedBrs, content: pc });
     }
 
-    // Build slot-variable lookup from the paired BRS:
-    //   m.homeView = m.top.findNode("homeView")  => { "m.homeView": "homeView" }
+    // Optional enrichment: scan for configurable helper-call patterns in the
+    // paired BRS. Each call site with a literal `true` second arg upgrades
+    // the matching route to MODAL. Missing call-sites don't drop the route.
     const varToSlot: Record<string, string> = {};
     for (const src of brsSources) {
       Object.assign(varToSlot, extractFindNodeBindings(src.content));
     }
 
     for (const src of brsSources) {
-      const calls = extractBrightScriptShowScreenCalls(src.content);
+      const calls = extractBrightScriptNavigationCalls(src.content, helperNames);
       const tags = detectTags(src.content);
       for (const call of calls) {
-        if (call.helper !== "show") continue;
+        // Resolve `m.homeView` -> slot id "homeView"; fall back to stripping
+        // the `m.` prefix when findNode binding wasn't captured.
         const slot = varToSlot[call.target] ?? call.target.replace(/^m\./, "");
-        const componentType = slotToType[slot];
-        const routeFile = componentType ? (componentToFile.get(componentType) ?? scene.file) : scene.file;
-        const method = call.modal ? "MODAL" : "VIEW";
         const path = `/${slot}`;
-        const key = `${method}:${path}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        routes.push({
-          method,
+        const existing = seen.get(path);
+        if (existing) {
+          if (call.modal && existing.method !== "MODAL") {
+            existing.method = "MODAL";
+          }
+          // Merge tags into the existing route
+          for (const tag of tags) {
+            if (!existing.tags.includes(tag)) existing.tags.push(tag);
+          }
+          continue;
+        }
+        // Call-site mentions a slot we didn't discover in <children> — emit
+        // a route for it anyway so custom overlays still appear.
+        const componentType = slotToType[slot];
+        const routeFile = componentType
+          ? (componentToFile.get(componentType) ?? scene.file)
+          : scene.file;
+        const route: RouteInfo = {
+          method: call.modal ? "MODAL" : "VIEW",
           path,
           file: routeFile,
-          tags,
+          tags: [...tags],
           framework: "roku-scenegraph",
           confidence: "regex",
-        });
+        };
+        seen.set(path, route);
+        routes.push(route);
       }
     }
   }

--- a/src/detectors/schema.ts
+++ b/src/detectors/schema.ts
@@ -71,6 +71,9 @@ export async function detectSchemas(
       case "room":
         models.push(...(await detectRoomSchemas(files, project)));
         break;
+      case "scenegraph":
+        models.push(...(await detectSceneGraphSchemas(files, project)));
+        break;
     }
   }
 
@@ -1080,6 +1083,40 @@ async function detectRoomSchemas(
     if (!content || !content.includes("@Entity")) continue;
     const rel = relative(project.root, file).replace(/\\/g, "/");
     models.push(...extractRoomEntities(rel, content));
+  }
+
+  return models;
+}
+
+// ─── SceneGraph schemas ───────────────────────────────────────────────────────
+//
+// Each SceneGraph component XML may declare an <interface> listing typed
+// fields + functions that form the component's public contract. This is the
+// closest Roku analog to an ORM model — a name + typed field set.
+async function detectSceneGraphSchemas(
+  files: string[],
+  project: ProjectInfo
+): Promise<SchemaModel[]> {
+  const { extractSceneGraphComponent, isSceneGraphXml } = await import("../ast/extract-scenegraph.js");
+  const xmlFiles = files.filter((f) => f.endsWith(".xml"));
+  const models: SchemaModel[] = [];
+  const seen = new Set<string>();
+
+  for (const file of xmlFiles) {
+    const content = await readFileSafe(file);
+    if (!content || !isSceneGraphXml(content)) continue;
+    const comp = extractSceneGraphComponent(content);
+    if (!comp) continue;
+    if (comp.interfaceFields.length === 0) continue;
+    if (seen.has(comp.name)) continue;
+    seen.add(comp.name);
+    models.push({
+      name: comp.name,
+      fields: comp.interfaceFields,
+      relations: [],
+      orm: "scenegraph",
+      confidence: "regex",
+    });
   }
 
   return models;

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -37,6 +37,8 @@ const IGNORE_DIRS = new Set([
   "deps",      // Elixir / mix — equivalent to node_modules for Phoenix/Ecto projects
   "_build",    // Elixir / mix — compiled .beam artifacts, analogous to `dist`/`build`
   "target",    // Rust / cargo — build output, compiled binaries + cached deps
+  ".roku-deploy-staging", // Roku / roku-deploy — staging artifacts
+  "roku_modules",        // Roku / ropm — third-party dependencies, analogous to node_modules
 ]);
 
 const CODE_EXTENSIONS = new Set([
@@ -60,6 +62,9 @@ const CODE_EXTENSIONS = new Set([
   ".dart",
   ".swift",
   ".cs",
+  ".brs",
+  ".bs",
+  ".xml",
   // Additional file types for new detectors
   ".graphql",
   ".gql",
@@ -155,7 +160,13 @@ export async function collectFiles(
         await walk(fullPath, depth + 1);
       } else if (entry.isFile()) {
         const ext = extname(entry.name);
-        if (CODE_EXTENSIONS.has(ext) || entry.name === ".env" || entry.name === ".env.example" || entry.name === ".env.local") {
+        if (
+          CODE_EXTENSIONS.has(ext) ||
+          entry.name === ".env" ||
+          entry.name === ".env.example" ||
+          entry.name === ".env.local" ||
+          entry.name === "manifest"
+        ) {
           files.push(fullPath);
         }
       }
@@ -266,6 +277,7 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
       actix: "rust", axum: "rust",
       aspnet: "csharp",
       gin: "go", fiber: "go", echo: "go", chi: "go", "go-net-http": "go",
+      "roku-scenegraph": "brightscript",
     };
     const wsLangs = new Set<string>();
     if (language === "typescript" || language === "javascript" || allDeps["react"] || allDeps["typescript"]) {
@@ -291,7 +303,7 @@ export async function detectProject(root: string): Promise<ProjectInfo> {
     "nestjs", "elysia", "adonis", "trpc", "sveltekit", "remix", "nuxt",
     "raw-http", "angular",
   ]);
-  const nonJSLangs = new Set(["go", "python", "ruby", "elixir", "java", "kotlin", "rust", "php", "dart", "swift", "csharp"]);
+  const nonJSLangs = new Set(["go", "python", "ruby", "elixir", "java", "kotlin", "rust", "php", "dart", "swift", "csharp", "brightscript"]);
   if (nonJSLangs.has(language) && frameworks.some((f) => !jsOnlyFrameworks.has(f))) {
     frameworks = frameworks.filter((f) => !jsOnlyFrameworks.has(f));
   }
@@ -313,6 +325,19 @@ async function discoverImplicitWorkspaces(
   repoRoot: string,
   workspaces: WorkspaceInfo[]
 ): Promise<void> {
+  // Roku repos often nest channels under src/apps/<creator>/ (depth 3+ from root).
+  // Do a dedicated deeper walk for `manifest` files before the generic depth-2 pass.
+  try {
+    const rokuDirs = await findRokuManifestDirs(repoRoot, 4);
+    for (const dir of rokuDirs) {
+      if (dir === repoRoot) continue; // root is handled by detectProject itself
+      const wsInfo = await detectNonJSWorkspace(repoRoot, dir, basename(dir));
+      if (wsInfo && !workspaces.some((w) => w.path === wsInfo.path)) {
+        workspaces.push(wsInfo);
+      }
+    }
+  } catch {}
+
   try {
     const topDirs = await readdir(repoRoot, { withFileTypes: true });
     for (const d of topDirs) {
@@ -405,6 +430,9 @@ async function hasDirectWorkspaceManifest(dir: string): Promise<boolean> {
   for (const manifest of directManifestNames) {
     if (await fileExists(join(dir, manifest))) return true;
   }
+
+  // Roku channel — plain-text `manifest` file at dir root
+  if (await hasRokuManifest(dir)) return true;
 
   try {
     const entries = await readdir(dir);
@@ -613,6 +641,11 @@ async function detectFrameworks(
     } catch {}
   }
 
+  // Roku / SceneGraph — plain-text `manifest` file at root with title + major_version
+  if (await hasRokuManifest(root)) {
+    frameworks.push("roku-scenegraph");
+  }
+
   // Android
   const hasAndroidManifest =
     (await fileExists(join(root, "app", "src", "main", "AndroidManifest.xml"))) ||
@@ -712,6 +745,11 @@ async function detectORMs(
   const androidDeps = await getAndroidDeps(root);
   if (androidDeps.some((d) => d.includes("androidx.room"))) orms.push("room");
 
+  // Roku / SceneGraph — every SceneGraph component's <interface> is a typed
+  // contract (name + typed fields), which is the core "schema model" notion
+  // codesight expresses. Auto-add whenever the Roku channel is detected.
+  if (await hasRokuManifest(root)) orms.push("scenegraph");
+
   // Entity Framework (ASP.NET) — check all csproj files
   const allCsprojForOrm = await findAllCsproj(root);
   for (const cp of allCsprojForOrm) {
@@ -737,13 +775,14 @@ function detectComponentFramework(
   if (frameworks.includes("flutter")) return "flutter";
   if (frameworks.includes("android")) return "jetpack-compose";
   if (frameworks.includes("angular")) return "angular";
+  if (frameworks.includes("roku-scenegraph")) return "scenegraph";
   return "unknown";
 }
 
 async function detectLanguage(
   root: string,
   deps: Record<string, string>
-): Promise<"typescript" | "javascript" | "python" | "go" | "ruby" | "elixir" | "java" | "kotlin" | "rust" | "php" | "dart" | "swift" | "csharp" | "mixed"> {
+): Promise<"typescript" | "javascript" | "python" | "go" | "ruby" | "elixir" | "java" | "kotlin" | "rust" | "php" | "dart" | "swift" | "csharp" | "brightscript" | "mixed"> {
   const hasTsConfig = await fileExists(join(root, "tsconfig.json"));
   const hasPyProject = await fileExists(join(root, "pyproject.toml")) || await fileExists(join(root, "backend/pyproject.toml"));
   const hasGoMod = await fileExists(join(root, "go.mod"));
@@ -767,6 +806,7 @@ async function detectLanguage(
   const hasCsproj = await (async () => {
     try { return (await readdir(root)).some((e) => e.endsWith(".csproj") || e.endsWith(".sln")); } catch { return false; }
   })();
+  const hasRokuChannel = await hasRokuManifest(root);
 
   const langs: string[] = [];
   if (hasTsConfig || deps["typescript"]) langs.push("typescript");
@@ -781,10 +821,11 @@ async function detectLanguage(
   if (hasPubspec) langs.push("dart");
   if (hasPackageSwift) langs.push("swift");
   if (hasCsproj) langs.push("csharp");
+  if (hasRokuChannel) langs.push("brightscript");
 
   if (langs.length > 1) {
     const primaryManifests: string[] = [
-      "go", "rust", "ruby", "elixir", "swift", "dart", "csharp", "java", "kotlin", "php", "python",
+      "go", "rust", "ruby", "elixir", "swift", "dart", "csharp", "java", "kotlin", "php", "python", "brightscript",
     ];
     const primary = langs.filter((l) => primaryManifests.includes(l));
     if (primary.length === 1) return primary[0] as any;
@@ -799,6 +840,7 @@ async function detectLanguage(
     if (entries.some((e) => e.endsWith(".swift"))) return "swift";
     if (entries.some((e) => e.endsWith(".cs"))) return "csharp";
     if (entries.some((e) => e.endsWith(".dart"))) return "dart";
+    if (entries.some((e) => e.endsWith(".brs") || e.endsWith(".bs"))) return "brightscript";
   } catch {}
 
   return "javascript";
@@ -974,6 +1016,12 @@ async function detectNonJSWorkspace(
       if (gemfile.includes("rails")) frameworks.push("rails");
       if (gemfile.includes("activerecord") || gemfile.includes("rails")) orms.push("activerecord");
     } catch {}
+  }
+
+  // Roku / SceneGraph (workspace-level) — channel dir with plain `manifest` file
+  if (await hasRokuManifest(wsPath)) {
+    frameworks.push("roku-scenegraph");
+    orms.push("scenegraph");
   }
 
   if (frameworks.length === 0) return null;
@@ -1231,6 +1279,57 @@ async function findAllCsproj(dir: string, depth = 0, results: string[] = []): Pr
       }
     }
   } catch {}
+  return results;
+}
+
+/**
+ * Check whether a directory looks like a Roku channel.
+ *
+ * Roku apps are anchored by a plain text file named `manifest` (no extension)
+ * at the channel root, containing key=value lines including `title=` and
+ * `major_version=`. This is the definitive Roku signal — no other ecosystem
+ * uses this exact pattern, so no secondary signals are needed.
+ */
+export async function hasRokuManifest(dir: string): Promise<boolean> {
+  const manifestPath = join(dir, "manifest");
+  try {
+    const s = await stat(manifestPath);
+    if (!s.isFile()) return false;
+    const content = await readFile(manifestPath, "utf-8");
+    return /^\s*title\s*=/m.test(content) && /^\s*major_version\s*=/m.test(content);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk up to a shallow depth looking for any Roku manifest. This is used to
+ * detect Roku repos whose channel directories live under a conventional
+ * `src/apps/<creator>/` tree rather than at the repo root.
+ */
+export async function findRokuManifestDirs(root: string, maxDepth = 4): Promise<string[]> {
+  const results: string[] = [];
+  const skip = new Set(["node_modules", ".git", "out", "dist", "build", ".roku-deploy-staging", "roku_modules"]);
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > maxDepth) return;
+    if (await hasRokuManifest(dir)) {
+      results.push(dir);
+      // Don't descend into a confirmed channel — sub-components live here,
+      // not further channels.
+      return;
+    }
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      for (const e of entries) {
+        if (!e.isDirectory()) continue;
+        if (e.name.startsWith(".") || skip.has(e.name) || IGNORE_DIRS.has(e.name)) continue;
+        await walk(join(dir, e.name), depth + 1);
+      }
+    } catch {}
+  }
+
+  await walk(root, 0);
   return results;
 }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -325,15 +325,21 @@ async function discoverImplicitWorkspaces(
   repoRoot: string,
   workspaces: WorkspaceInfo[]
 ): Promise<void> {
-  // Roku repos often nest channels under src/apps/<creator>/ (depth 3+ from root).
-  // Do a dedicated deeper walk for `manifest` files before the generic depth-2 pass.
+  // Roku multi-channel monorepo: signal requires roku-deploy + a
+  // `common/` + >=2 sibling-channel structure. Won't fire on the 90% single-
+  // channel case or on non-Roku repos that happen to have a `manifest` file.
   try {
-    const rokuDirs = await findRokuManifestDirs(repoRoot, 4);
-    for (const dir of rokuDirs) {
-      if (dir === repoRoot) continue; // root is handled by detectProject itself
-      const wsInfo = await detectNonJSWorkspace(repoRoot, dir, basename(dir));
-      if (wsInfo && !workspaces.some((w) => w.path === wsInfo.path)) {
-        workspaces.push(wsInfo);
+    const rokuMono = await detectRokuMonorepo(repoRoot);
+    if (rokuMono) {
+      // Each channel dir becomes a workspace. The `common/` dir isn't a
+      // shippable channel, but it contains the bulk of the shared code —
+      // register it as a workspace too so its components/schemas show up.
+      const dirs = [rokuMono.commonDir, ...rokuMono.channelDirs];
+      for (const dir of dirs) {
+        const wsInfo = await detectNonJSWorkspace(repoRoot, dir, basename(dir));
+        if (wsInfo && !workspaces.some((w) => w.path === wsInfo.path)) {
+          workspaces.push(wsInfo);
+        }
       }
     }
   } catch {}
@@ -641,8 +647,10 @@ async function detectFrameworks(
     } catch {}
   }
 
-  // Roku / SceneGraph — plain-text `manifest` file at root with title + major_version
-  if (await hasRokuManifest(root)) {
+  // Roku / SceneGraph — plain-text `manifest` file at root with title + major_version.
+  // Also matches the rokucommunity/brighterscript-template layout where the
+  // manifest lives under `src/` and root carries a bsconfig.json marker.
+  if (await hasRokuManifest(root) || await detectBrighterScriptTemplateRoot(root)) {
     frameworks.push("roku-scenegraph");
   }
 
@@ -748,7 +756,9 @@ async function detectORMs(
   // Roku / SceneGraph — every SceneGraph component's <interface> is a typed
   // contract (name + typed fields), which is the core "schema model" notion
   // codesight expresses. Auto-add whenever the Roku channel is detected.
-  if (await hasRokuManifest(root)) orms.push("scenegraph");
+  if (await hasRokuManifest(root) || await detectBrighterScriptTemplateRoot(root)) {
+    orms.push("scenegraph");
+  }
 
   // Entity Framework (ASP.NET) — check all csproj files
   const allCsprojForOrm = await findAllCsproj(root);
@@ -806,7 +816,7 @@ async function detectLanguage(
   const hasCsproj = await (async () => {
     try { return (await readdir(root)).some((e) => e.endsWith(".csproj") || e.endsWith(".sln")); } catch { return false; }
   })();
-  const hasRokuChannel = await hasRokuManifest(root);
+  const hasRokuChannel = await hasRokuManifest(root) || await detectBrighterScriptTemplateRoot(root);
 
   const langs: string[] = [];
   if (hasTsConfig || deps["typescript"]) langs.push("typescript");
@@ -1303,34 +1313,123 @@ export async function hasRokuManifest(dir: string): Promise<boolean> {
 }
 
 /**
- * Walk up to a shallow depth looking for any Roku manifest. This is used to
- * detect Roku repos whose channel directories live under a conventional
- * `src/apps/<creator>/` tree rather than at the repo root.
+ * Detect the `rokucommunity/brighterscript-template` layout:
+ *   - no manifest at root
+ *   - bsconfig.json at root (BrighterScript project marker)
+ *   - exactly one `src/manifest` with the standard channel signature
+ *
+ * Treat the root as a single Roku channel rooted at `src/`. Prevents the
+ * generic monorepo walker from promoting `src/` to a workspace and leaving
+ * the root framework as `raw-http`.
  */
-export async function findRokuManifestDirs(root: string, maxDepth = 4): Promise<string[]> {
-  const results: string[] = [];
-  const skip = new Set(["node_modules", ".git", "out", "dist", "build", ".roku-deploy-staging", "roku_modules"]);
+export async function detectBrighterScriptTemplateRoot(dir: string): Promise<boolean> {
+  if (await hasRokuManifest(dir)) return false;
+  const bsConfigPath = join(dir, "bsconfig.json");
+  try {
+    await stat(bsConfigPath);
+  } catch {
+    return false;
+  }
+  return hasRokuManifest(join(dir, "src"));
+}
 
-  async function walk(dir: string, depth: number): Promise<void> {
-    if (depth > maxDepth) return;
-    if (await hasRokuManifest(dir)) {
-      results.push(dir);
-      // Don't descend into a confirmed channel — sub-components live here,
-      // not further channels.
-      return;
-    }
-    try {
-      const entries = await readdir(dir, { withFileTypes: true });
-      for (const e of entries) {
-        if (!e.isDirectory()) continue;
-        if (e.name.startsWith(".") || skip.has(e.name) || IGNORE_DIRS.has(e.name)) continue;
-        await walk(join(dir, e.name), depth + 1);
-      }
-    } catch {}
+/**
+ * Detect a Roku multi-channel monorepo layout. 90% of Roku repos are
+ * single-channel (manifest at root), but a small set of larger codebases
+ * ship multiple channels from one repo using `roku-deploy` + `gulp` to merge
+ * per-channel assets with a shared `common/` layer at build time.
+ *
+ * Required signals (all must hold):
+ *   1. No manifest at `root` (otherwise it's a standard single-channel repo)
+ *   2. `root/package.json` declares `roku-deploy` in deps or devDeps
+ *   3. Some container dir `C` contains:
+ *        - a `common/` subdirectory, AND
+ *        - at least 2 sibling directories of `common/` that each have their
+ *          own `manifest` file
+ *
+ * When these match, returns `{ containerDir, channelDirs, commonDir }`.
+ * Otherwise returns null and the caller treats the repo as single-channel
+ * (or not a Roku repo at all).
+ */
+export async function detectRokuMonorepo(
+  root: string
+): Promise<{ containerDir: string; channelDirs: string[]; commonDir: string } | null> {
+  // Signal 1: no root manifest
+  if (await hasRokuManifest(root)) return null;
+
+  // Signal 2: roku-deploy in package.json
+  try {
+    const pkgRaw = await readFile(join(root, "package.json"), "utf-8");
+    const pkg = JSON.parse(pkgRaw) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+    const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+    if (!deps["roku-deploy"]) return null;
+  } catch {
+    return null;
   }
 
-  await walk(root, 0);
-  return results;
+  // Signal 3: find a container dir with common/ + >=2 sibling channels.
+  // Limit search to shallow depth; the common-plus-channels layout is always
+  // near the top of the repo tree (usually at root or one level down).
+  const skip = new Set([
+    "node_modules", ".git", "out", "dist", "build",
+    ".roku-deploy-staging", "roku_modules", ".gradle",
+  ]);
+
+  const visit = async (dir: string): Promise<{ containerDir: string; channelDirs: string[]; commonDir: string } | null> => {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return null;
+    }
+
+    const subdirs = entries.filter(
+      (e) => e.isDirectory() && !e.name.startsWith(".") && !skip.has(e.name) && !IGNORE_DIRS.has(e.name)
+    );
+    const commonDir = subdirs.find((e) => e.name.toLowerCase() === "common");
+    if (commonDir) {
+      const channelDirs: string[] = [];
+      for (const sub of subdirs) {
+        if (sub === commonDir) continue;
+        if (await hasRokuManifest(join(dir, sub.name))) {
+          channelDirs.push(join(dir, sub.name));
+        }
+      }
+      if (channelDirs.length >= 2) {
+        return {
+          containerDir: dir,
+          channelDirs,
+          commonDir: join(dir, commonDir.name),
+        };
+      }
+    }
+    return null;
+  };
+
+  // Try root first, then common one-level-deep parents (e.g. `src/apps/`).
+  const hit = await visit(root);
+  if (hit) return hit;
+  try {
+    const topEntries = await readdir(root, { withFileTypes: true });
+    for (const e of topEntries) {
+      if (!e.isDirectory() || e.name.startsWith(".") || skip.has(e.name) || IGNORE_DIRS.has(e.name)) continue;
+      const firstLevel = join(root, e.name);
+      const firstHit = await visit(firstLevel);
+      if (firstHit) return firstHit;
+      // One more level — covers e.g. `src/apps/` where `src/` itself holds the container.
+      try {
+        const nested = await readdir(firstLevel, { withFileTypes: true });
+        for (const n of nested) {
+          if (!n.isDirectory() || n.name.startsWith(".") || skip.has(n.name) || IGNORE_DIRS.has(n.name)) continue;
+          const secondLevel = join(firstLevel, n.name);
+          const secondHit = await visit(secondLevel);
+          if (secondHit) return secondHit;
+        }
+      } catch {}
+    }
+  } catch {}
+
+  return null;
 }
 
 async function fileExists(path: string): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,15 +34,17 @@ export type Framework =
   | "swiftui"
   | "flutter"
   | "android"
+  | "roku-scenegraph"
   | "graphql"
   | "grpc"
   | "websocket"
   | "angular"
   | "unknown";
 
-export type ORM = "drizzle" | "prisma" | "typeorm" | "sqlalchemy" | "django" | "gorm" | "ent" | "mongoose" | "sequelize" | "activerecord" | "ecto" | "eloquent" | "entity-framework" | "exposed" | "room" | "unknown";
+export type ORM = "drizzle" | "prisma" | "typeorm" | "sqlalchemy" | "django" | "gorm" | "ent" | "mongoose" | "sequelize" | "activerecord" | "ecto" | "eloquent" | "entity-framework" | "exposed" | "room" | "scenegraph" | "unknown";
 
-export type ComponentFramework = "react" | "vue" | "svelte" | "flutter" | "jetpack-compose" | "angular" | "unknown";
+export type ComponentFramework = "react" | "vue" | "svelte" | "flutter" | "jetpack-compose" | "angular" | "scenegraph" | "unknown";
+
 
 export type KnowledgeNoteType = "decision" | "meeting" | "retro" | "spec" | "backlog" | "research" | "session" | "general";
 
@@ -82,7 +84,7 @@ export interface ProjectInfo {
   isMonorepo: boolean;
   repoType: RepoType;
   workspaces: WorkspaceInfo[];
-  language: "typescript" | "javascript" | "python" | "go" | "ruby" | "elixir" | "java" | "kotlin" | "rust" | "php" | "dart" | "swift" | "csharp" | "mixed";
+  language: "typescript" | "javascript" | "python" | "go" | "ruby" | "elixir" | "java" | "kotlin" | "rust" | "php" | "dart" | "swift" | "csharp" | "brightscript" | "mixed";
 }
 
 export interface WorkspaceInfo {
@@ -239,7 +241,7 @@ export interface PluginDetectorResult {
 export interface EventInfo {
   name: string;
   type: "queue" | "topic" | "event" | "channel";
-  system: "bullmq" | "kafka" | "redis-pub-sub" | "socket.io" | "eventemitter" | "unknown";
+  system: "bullmq" | "kafka" | "redis-pub-sub" | "socket.io" | "eventemitter" | "scenegraph-observer" | "rudderstack" | "unknown";
   file: string;
   payloadType?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,6 +216,13 @@ export interface CodesightConfig {
   plugins?: CodesightPlugin[];
   /** Monorepo configuration */
   monorepo?: MonorepoConfig;
+  /**
+   * Roku only: helper names used in BRS to open a screen/view. Defaults to
+   * ["ShowScreen", "showScreen", "pushScreen", "PushScreen", "NavigateTo",
+   *  "navigateTo", "showView", "ShowView"]. Override when your project uses
+   * a different navigation helper convention.
+   */
+  rokuScreenHelpers?: string[];
 }
 
 export interface CodesightPlugin {

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -748,3 +748,216 @@ class Post(Base):
     await assertFastApiSqlAlchemyDetection(mods, dir, "container-dir/custom-python-backend", ["container-dir"]);
   });
 });
+
+// =================== ROKU / SCENEGRAPH TESTS ===================
+//
+// Covers the full Roku pipeline: project detection, routes as screens,
+// schema from <interface> fields, components from XML, libs from .brs / .bs,
+// and dependency edges from <script uri="pkg:/..."> + BrighterScript imports.
+
+const ROKU_MANIFEST = `title=Test Channel\nmajor_version=1\nminor_version=0\nbuild_version=0\nui_resolutions=fhd\n`;
+
+const ROKU_MAIN_SCENE_XML = `<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+  <children>
+    <HomeView id="homeView" />
+    <LoginView id="loginView" />
+    <ErrorModal id="errorModal" />
+  </children>
+  <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+</component>
+`;
+
+const ROKU_MAIN_SCENE_BRS = `sub init()
+    m.homeView = m.top.findNode("homeView")
+    m.loginView = m.top.findNode("loginView")
+    m.errorModal = m.top.findNode("errorModal")
+    m.top.observeField("someField", "handleSome")
+    m.global.AddField("token", "string", false)
+    ShowScreen(m.homeView)
+end sub
+
+sub showLogin()
+    ShowScreen(m.loginView, true)
+end sub
+
+sub showError()
+    ShowScreen(m.errorModal, true)
+end sub
+`;
+
+const ROKU_HOME_VIEW_XML = `<?xml version="1.0" encoding="utf-8" ?>
+<component name="HomeView" extends="Group">
+  <interface>
+    <field id="pageID" type="String" />
+    <field id="channelID" type="String" />
+  </interface>
+  <script type="text/brightscript" uri="pkg:/components/views/HomeView.brs" />
+</component>
+`;
+
+const ROKU_HOME_VIEW_BRS = `sub init()
+end sub
+`;
+
+const ROKU_LOGIN_VIEW_XML = `<?xml version="1.0" encoding="utf-8" ?>
+<component name="LoginView" extends="Group">
+  <interface>
+    <field id="email" type="String" />
+  </interface>
+  <script type="text/brightscript" uri="pkg:/components/views/LoginView.brs" />
+</component>
+`;
+
+const ROKU_LOGIN_VIEW_BRS = `sub init()
+end sub
+`;
+
+const ROKU_ERROR_MODAL_XML = `<?xml version="1.0" encoding="utf-8" ?>
+<component name="ErrorModal" extends="Group">
+  <interface>
+    <field id="message" type="String" />
+  </interface>
+</component>
+`;
+
+const ROKU_DATA_TASK_XML = `<?xml version="1.0" encoding="utf-8" ?>
+<component name="DataTask" extends="Task">
+  <interface>
+    <field id="requestUrl" type="String" />
+    <field id="response" type="assocarray" />
+  </interface>
+  <script type="text/brightscript" uri="pkg:/components/tasks/DataTask.brs" />
+</component>
+`;
+
+const ROKU_DATA_TASK_BRS = `sub init()
+    m.top.functionName = "fetchData"
+end sub
+
+function fetchData() as object
+    response = makeGraphqlCall(m.top.requestUrl, "{}", {})
+    return response
+end function
+`;
+
+const ROKU_UTILS_BRS = `function helperFormat(input as string) as string
+    return input
+end function
+
+sub helperLog(msg as string)
+    print msg
+end sub
+`;
+
+const ROKU_HELPERS_BS = `import "pkg:/source/utils/Utils.brs"
+
+namespace app.helpers
+end namespace
+
+class RokuHelper
+    function sayHi() as string
+        return "hi"
+    end function
+end class
+`;
+
+describe("Roku SceneGraph Detection", async () => {
+  const mods = await loadModules();
+
+  it("detects Roku project + routes + schemas + components + libs + graph", async () => {
+    const dir = await writeFixture("roku-channel", {
+      "manifest": ROKU_MANIFEST,
+      "components/MainScene.xml": ROKU_MAIN_SCENE_XML,
+      "components/MainScene.brs": ROKU_MAIN_SCENE_BRS,
+      "components/views/HomeView.xml": ROKU_HOME_VIEW_XML,
+      "components/views/HomeView.brs": ROKU_HOME_VIEW_BRS,
+      "components/views/LoginView.xml": ROKU_LOGIN_VIEW_XML,
+      "components/views/LoginView.brs": ROKU_LOGIN_VIEW_BRS,
+      "components/views/ErrorModal.xml": ROKU_ERROR_MODAL_XML,
+      "components/tasks/DataTask.xml": ROKU_DATA_TASK_XML,
+      "components/tasks/DataTask.brs": ROKU_DATA_TASK_BRS,
+      "source/utils/Utils.brs": ROKU_UTILS_BRS,
+      "source/Helpers.bs": ROKU_HELPERS_BS,
+    });
+
+    // 1. Project detection
+    const project = await mods.detectProject(dir);
+    assert.equal(project.language, "brightscript", `expected brightscript language, got ${project.language}`);
+    assert.ok(project.frameworks.includes("roku-scenegraph"), `expected roku-scenegraph framework, got ${project.frameworks.join(", ")}`);
+    assert.equal(project.componentFramework, "scenegraph", `expected scenegraph componentFramework, got ${project.componentFramework}`);
+    assert.ok(project.orms.includes("scenegraph"), `expected scenegraph orm, got ${project.orms.join(", ")}`);
+
+    const files = await mods.collectFiles(dir);
+
+    // 2. Routes: one VIEW per ShowScreen(m.homeView), MODAL for the 2nd-arg-true calls
+    const routes = await mods.detectRoutes(files, project);
+    const home = routes.find((r: any) => r.path === "/homeView");
+    const login = routes.find((r: any) => r.path === "/loginView");
+    const err = routes.find((r: any) => r.path === "/errorModal");
+    assert.ok(home, `expected /homeView route, got ${routes.map((r: any) => `${r.method} ${r.path}`).join(", ")}`);
+    assert.equal(home.method, "VIEW", `expected VIEW method, got ${home.method}`);
+    assert.ok(home.file.endsWith("HomeView.xml"), `expected file HomeView.xml, got ${home.file}`);
+    assert.ok(login, `expected /loginView route`);
+    assert.equal(login.method, "MODAL", `expected MODAL method, got ${login.method}`);
+    assert.ok(err, `expected /errorModal route`);
+    assert.equal(err.method, "MODAL");
+
+    // 3. Schemas: HomeView + LoginView + ErrorModal + DataTask (all have <interface>)
+    const schemas = await mods.detectSchemas(files, project);
+    const names = schemas.map((s: any) => s.name);
+    assert.ok(names.includes("HomeView"), `expected HomeView schema, got ${names.join(", ")}`);
+    assert.ok(names.includes("DataTask"), `expected DataTask schema, got ${names.join(", ")}`);
+    const dataTask = schemas.find((s: any) => s.name === "DataTask");
+    assert.equal(dataTask.orm, "scenegraph");
+    assert.ok(dataTask.fields.some((f: any) => f.name === "requestUrl" && f.type === "string"));
+    assert.ok(dataTask.fields.some((f: any) => f.name === "response" && f.type === "object"));
+
+    // 4. Components: every SceneGraph XML (MainScene, HomeView, LoginView, ErrorModal, DataTask)
+    const components = await mods.detectComponents(files, project);
+    const compNames = components.map((c: any) => c.name);
+    assert.ok(compNames.includes("HomeView"));
+    assert.ok(compNames.includes("DataTask"));
+    assert.ok(compNames.includes("MainScene"));
+    const homeComp = components.find((c: any) => c.name === "HomeView");
+    assert.deepEqual(homeComp.props.sort(), ["channelID", "pageID"]);
+
+    // 5. Libs: Utils.brs functions + Helpers.bs class + namespace + folded-in fns
+    const libs = await mods.detectLibs(files, project);
+    const utilsLib = libs.find((l: any) => l.file.endsWith("Utils.brs"));
+    assert.ok(utilsLib, `expected Utils.brs lib, got ${libs.map((l: any) => l.file).join(", ")}`);
+    assert.ok(utilsLib.exports.some((e: any) => e.name === "helperFormat" && e.kind === "function"));
+    assert.ok(utilsLib.exports.some((e: any) => e.name === "helperLog" && e.kind === "function"));
+
+    const helpersLib = libs.find((l: any) => l.file.endsWith("Helpers.bs"));
+    assert.ok(helpersLib, `expected Helpers.bs lib, got ${libs.map((l: any) => l.file).join(", ")}`);
+    assert.ok(helpersLib.exports.some((e: any) => e.name === "RokuHelper" && e.kind === "class"));
+
+    // 6. Dependency graph: BrighterScript `import` edge + MainScene.xml <script uri=...> edges
+    const graph = await mods.detectDependencyGraph(files, project);
+    const hasImportEdge = graph.edges.some(
+      (e: any) => e.from.endsWith("Helpers.bs") && e.to.endsWith("Utils.brs")
+    );
+    assert.ok(hasImportEdge, `expected Helpers.bs -> Utils.brs edge, got ${graph.edges.map((e: any) => `${e.from}->${e.to}`).join(", ")}`);
+    const hasScriptEdge = graph.edges.some(
+      (e: any) => e.from.endsWith("MainScene.xml") && e.to.endsWith("MainScene.brs")
+    );
+    assert.ok(hasScriptEdge, `expected MainScene.xml -> MainScene.brs edge, got ${graph.edges.map((e: any) => `${e.from}->${e.to}`).join(", ")}`);
+
+    // 7. Config: Roku manifest surfaces as env-like vars and shows up in configFiles
+    const config = await mods.detectConfig(files, project);
+    assert.ok(config.configFiles.includes("manifest"), `expected manifest in configFiles, got ${config.configFiles.join(", ")}`);
+    assert.ok(config.envVars.some((e: any) => e.name === "manifest.title"), `expected manifest.title env var, got ${config.envVars.map((e: any) => e.name).join(", ")}`);
+
+    // 8. Middleware: observeField + m.global.AddField show up as custom middleware
+    const middleware = await mods.detectMiddleware(files, project);
+    assert.ok(
+      middleware.some((mw: any) => mw.name.includes("observeField(someField)")),
+      `expected observeField middleware, got ${middleware.map((mw: any) => mw.name).join(", ")}`
+    );
+    assert.ok(
+      middleware.some((mw: any) => mw.name === "m.global.token: string"),
+      `expected m.global.token middleware, got ${middleware.map((mw: any) => mw.name).join(", ")}`
+    );
+  });
+});

--- a/tests/detectors.test.ts
+++ b/tests/detectors.test.ts
@@ -865,6 +865,153 @@ end class
 describe("Roku SceneGraph Detection", async () => {
   const mods = await loadModules();
 
+  it("detects a kernel-roku-style single-channel project from <children> alone (no ShowScreen helper)", async () => {
+    // 90% of Roku repos look like this: manifest at root, source/ + components/,
+    // no custom navigation helper. The route surface comes entirely from
+    // MainScene.xml's <children> slots.
+    const dir = await writeFixture("roku-standard-channel", {
+      "manifest": ROKU_MANIFEST,
+      "source/Main.brs": `sub Main()
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    while true
+        msg = wait(0, port)
+        msgType = type(msg)
+        if msgType = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub
+`,
+      "components/MainScene.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+  <children>
+    <HomeView id="homeView" visible="true" />
+    <DetailView id="detailView" visible="false" />
+  </children>
+  <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+</component>
+`,
+      "components/MainScene.brs": `sub init()
+    m.homeView = m.top.findNode("homeView")
+    m.detailView = m.top.findNode("detailView")
+    m.homeView.setFocus(true)
+end sub
+
+sub onItemSelected()
+    m.homeView.visible = false
+    m.detailView.visible = true
+    m.detailView.setFocus(true)
+end sub
+`,
+      "components/views/HomeView.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="HomeView" extends="Group">
+  <interface>
+    <field id="items" type="array" />
+  </interface>
+</component>
+`,
+      "components/views/DetailView.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="DetailView" extends="Group">
+  <interface>
+    <field id="itemId" type="String" />
+  </interface>
+</component>
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    assert.equal(project.language, "brightscript", `language: got ${project.language}`);
+    assert.ok(project.frameworks.includes("roku-scenegraph"));
+    assert.ok(!project.isMonorepo, "standard single-channel repo must not be flagged as monorepo");
+
+    const files = await mods.collectFiles(dir);
+    const routes = await mods.detectRoutes(files, project);
+
+    // Expect exactly two VIEW routes, derived purely from MainScene <children>.
+    // No ShowScreen helper exists in this fixture — the detector must not
+    // depend on one.
+    assert.equal(routes.length, 2, `expected 2 routes, got ${routes.length}: ${routes.map((r: any) => `${r.method} ${r.path}`).join(", ")}`);
+    const home = routes.find((r: any) => r.path === "/homeView");
+    const detail = routes.find((r: any) => r.path === "/detailView");
+    assert.ok(home, "expected /homeView route");
+    assert.equal(home.method, "VIEW");
+    assert.ok(home.file.endsWith("HomeView.xml"), `expected HomeView.xml, got ${home.file}`);
+    assert.ok(detail, "expected /detailView route");
+    assert.equal(detail.method, "VIEW");
+    assert.ok(detail.file.endsWith("DetailView.xml"));
+  });
+
+  it("detects rokucommunity/brighterscript-template layout (bsconfig.json + src/manifest)", async () => {
+    // BrighterScript template: TS tooling at root, actual Roku channel under src/.
+    const dir = await writeFixture("roku-brighterscript-template", {
+      "package.json": JSON.stringify({
+        name: "my-bsc-app",
+        devDependencies: { brighterscript: "^0.71.0" },
+      }),
+      "bsconfig.json": JSON.stringify({ rootDir: "src", files: ["**/*"] }),
+      "src/manifest": ROKU_MANIFEST,
+      "src/source/Main.brs": `sub Main()\n    screen = CreateObject("roSGScreen")\nend sub\n`,
+      "src/source/Utils.bs": `namespace app.utils\n    function greet() as string\n        return "hi"\n    end function\nend namespace\n`,
+      "src/components/MainScene.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+  <children>
+    <HomeView id="homeView" />
+  </children>
+</component>
+`,
+      "src/components/HomeView.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="HomeView" extends="Group">
+  <interface>
+    <field id="title" type="String" />
+  </interface>
+</component>
+`,
+    });
+
+    const project = await mods.detectProject(dir);
+    // Root must be identified as the Roku channel, not a workspace holder.
+    assert.ok(
+      project.frameworks.includes("roku-scenegraph"),
+      `expected root roku-scenegraph framework, got ${project.frameworks.join(", ")}`
+    );
+    assert.ok(
+      !project.isMonorepo,
+      "brighterscript-template is a single-channel project, must not be promoted to monorepo"
+    );
+
+    const files = await mods.collectFiles(dir);
+    const routes = await mods.detectRoutes(files, project);
+    const schemas = await mods.detectSchemas(files, project);
+    const components = await mods.detectComponents(files, project);
+
+    assert.ok(routes.some((r: any) => r.path === "/homeView"), `expected /homeView, got ${routes.map((r: any) => r.path).join(", ")}`);
+    assert.ok(schemas.some((s: any) => s.name === "HomeView"), `expected HomeView schema, got ${schemas.map((s: any) => s.name).join(", ")}`);
+    const mainScene = components.find((c: any) => c.name === "MainScene");
+    assert.ok(mainScene, "expected MainScene component");
+    assert.ok(mainScene.file.startsWith("src/"), `expected src/-rooted path, got ${mainScene.file}`);
+  });
+
+  it("does not promote a standard single-channel repo to a monorepo even when package.json has roku-deploy", async () => {
+    // A repo with roku-deploy but no common/ + channels layout is still single-channel.
+    const dir = await writeFixture("roku-deploy-single-channel", {
+      "manifest": ROKU_MANIFEST,
+      "package.json": JSON.stringify({
+        name: "single-channel",
+        devDependencies: { "roku-deploy": "^3.10.0" },
+      }),
+      "components/MainScene.xml": `<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene"></component>
+`,
+    });
+    const project = await mods.detectProject(dir);
+    assert.ok(!project.isMonorepo, "single-channel repo must not be labeled monorepo");
+    assert.ok(project.frameworks.includes("roku-scenegraph"));
+  });
+
   it("detects Roku project + routes + schemas + components + libs + graph", async () => {
     const dir = await writeFixture("roku-channel", {
       "manifest": ROKU_MANIFEST,


### PR DESCRIPTION
## Summary

Adds full codesight support for Roku apps. Anchors project detection on the plain-text `manifest` file (the same file Roku itself uses), adds three new regex-based extractors (BrightScript, BrighterScript, SceneGraph XML), and wires all 8 detectors to map Roku idioms onto codesight's existing data model.

Closes #<issue-number>.

**Layouts supported:**

- **Standard single-channel** (~90% of Roku repos, the getting-started template + `kernel-roku`-style): `manifest` + `source/` + `components/` at the repo root.
- **BrighterScript template** (`rokucommunity/brighterscript-template`): `bsconfig.json` at root, channel rooted under `src/`. Detected as a single channel, not promoted to a monorepo.
- **Multi-channel monorepo** (explicit exception — large codebases that ship several branded channels via `roku-deploy` + `gulp` merging a shared `common/` layer): each channel registered as its own workspace. Strict structural signal (no root manifest + `roku-deploy` in deps + `common/` + ≥2 sibling-channel dirs with manifests) so an ordinary single-channel repo that happens to have `roku-deploy` is never mis-labeled.

**Mapping:**

- **Routes** — every child with an `id` in a Scene XML's `<children>` becomes a route. `method = VIEW` by default, upgraded to `MODAL` when a configurable navigation helper (default set covers `ShowScreen`, `pushScreen`, `NavigateTo`, `showView`, plus camelCase variants) is called with a literal `true` second arg. Works on projects with no helper at all.
- **Schema** — `orm: "scenegraph"` models from every component XML with a non-empty `<interface>`. Field types normalized (`String`→`string`, `assocarray`→`object`, `node`→`node-ref`, etc.).
- **Components** — one per SceneGraph XML; props = interface field ids.
- **Libraries** — `.brs` functions/subs; `.bs` adds classes, namespaces, enums, interfaces on top. Files under `components/` are skipped (handler code, not libs).
- **Middleware** — `observeField` subscriptions, `m.global.AddField` registrations. BugsnagTask / RudderstackTask recognized when present.
- **Graph** — edges from `<script uri="pkg:/...">` in XML + `import "pkg:/..."` in `.bs`, with a suffix-match resolver for nested channel layouts.
- **Events** — observed fields (`system: scenegraph-observer`) + Rudderstack event names (`system: rudderstack`).
- **Config** — Roku `manifest` keys surfaced as `manifest.<name>` pseudo env-vars.

## Changes

- `types.ts` — adds `Framework: "roku-scenegraph"`, `ComponentFramework: "scenegraph"`, `ORM: "scenegraph"`, `language: "brightscript"`, `EventInfo.system: "scenegraph-observer" | "rudderstack"`, and a `CodesightConfig.rokuScreenHelpers?: string[]` option.
- `scanner.ts` — adds `.brs`, `.bs`, `.xml` to `CODE_EXTENSIONS`; bare `manifest` added as a non-extension exception; `roku_modules` + `.roku-deploy-staging` added to `IGNORE_DIRS`; new `hasRokuManifest()`, `detectBrighterScriptTemplateRoot()`, and `detectRokuMonorepo()` helpers (structural `common/` + ≥2 channels + `roku-deploy` signal); Roku language/framework/ORM + component framework branches; workspace discovery wires the monorepo detector in front of the generic depth-2 fallback.
- `ast/extract-scenegraph.ts` — new file. Parses `<component>`, `<interface>` fields + functions, `<script uri>` includes, `<children>`. Exposes `extractSceneGraphComponent`, `extractMainSceneScreens`, `isSceneGraphXml`.
- `ast/extract-brightscript.ts` — new file. `extractBrightScriptFunctions`, `extractBrightScriptObservers`, `extractBrightScriptNavigationCalls` (configurable helper names), `extractBrightScriptShowScreenCalls` (back-compat wrapper), `extractBrightScriptGraphqlCalls`, `extractBrightScriptGlobalFields`, `extractBrightScriptRudderstackEvents`, `extractFindNodeBindings`.
- `ast/extract-brighterscript.ts` — new file. `extractBrighterScriptImports` + `extractBrighterScriptExports` (classes, namespaces, enums, interfaces; composes with BrightScript extractor for functions/subs).
- `detectors/routes.ts` — new `case "roku-scenegraph"` branch + `detectRokuScreens()` helper. Children-first: `<children>` slots are the primary route surface; helper-call sites are optional enrichment that can flip VIEW→MODAL.
- `detectors/schema.ts` — new `case "scenegraph"` branch + `detectSceneGraphSchemas()` helper.
- `detectors/components.ts` — new `case "scenegraph"` branch + `detectSceneGraphComponents()` helper.
- `detectors/libs.ts` — `.brs`/`.bs` added to lib filter; dispatches to the new extractors. Filter now compares against the project-relative path, fixing a latent bug where any project hosted under a parent `tests/` directory had all its lib files silently dropped.
- `detectors/middleware.ts` — emits `observeField` + `m.global.AddField` as custom middleware, BugsnagTask as error-handler, RudderstackTask as logging.
- `detectors/graph.ts` — extended to `.brs`/`.bs`/`.xml`; new `extractSceneGraphImportsInline` + `extractBrighterScriptImportsInline` with a suffix-match resolver for `pkg:/...` URIs.
- `detectors/events.ts` — extended to `.brs`/`.bs`; emits scenegraph-observer + rudderstack events.
- `detectors/config.ts` — surfaces `manifest` in `configFiles` and manifest keys as `manifest.<name>` env vars.
- `README.md` — adds BrightScript/BrighterScript to the Works-with line, updates the Supported Stacks table, adds a `## Roku / BrightScript / SceneGraph` section that leads with the standard single-channel layout, documents the BrighterScript template variant, and calls out the multi-channel monorepo as an explicit exception with the structural signal described. Documents the `rokuScreenHelpers` config option.

## Tests

New `Roku SceneGraph Detection` suite in `tests/detectors.test.ts` with four fixtures and assertions:

1. **Kernel-roku-style single channel** with no navigation helper at all — asserts two VIEW routes are derived from MainScene's `<children>` alone, repo is not flagged as a monorepo.
2. **BrighterScript template** (`bsconfig.json` + `src/manifest`) — asserts root is identified as the Roku channel, schemas + components include `src/`-rooted paths, not promoted to monorepo.
3. **`roku-deploy` in deps but only one channel** — asserts the structural signal does not fire, repo is single-channel.
4. **Full multi-channel feature coverage** — asserts VIEW/MODAL routes, scenegraph schemas with normalized field types, components + props, `.brs` + `.bs` lib exports, script-include + import dependency edges, manifest config surfacing, and observeField/m.global middleware.

Full suite: **58/58 pass** (54 pre-existing + 4 new).

**Real-world smoke tests:**

- Synthetic kernel-roku-style channel (5 files, no navigation helper): detected as `roku-scenegraph | scenegraph | brightscript`, not a monorepo, 2 VIEW routes pulled from `<children>` alone.
- Multi-channel monorepo with 5 workspaces (common + 4 channels): still correctly detected as monorepo, 253 files scanned, 132K tokens saved per conversation.